### PR TITLE
updated bertopic notebook, preliminary dataset with topics

### DIFF
--- a/notebooks/BERTopic_Topic_Modeling.ipynb
+++ b/notebooks/BERTopic_Topic_Modeling.ipynb
@@ -83,7 +83,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 119,
+   "execution_count": 278,
    "metadata": {},
    "outputs": [
     {
@@ -102,6 +102,7 @@
    "source": [
     "import pandas as pd\n",
     "import numpy as np\n",
+    "import seaborn as sns\n",
     "\n",
     "from sklearn.model_selection import train_test_split\n",
     "from sklearn.feature_extraction.text import CountVectorizer, TfidfVectorizer\n",
@@ -3426,29 +3427,36 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 261,
+   "execution_count": 267,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "['why do you need phone number not nessisary.',\n",
-       " 'why do you need my phone number',\n",
-       " \"couldn't even use because no phone number with\"]"
+       "['great helpful should get a voice feature though',\n",
+       " 'it have to do something better for voice into text converter',\n",
+       " 'voice to speech feature is not so good but chatgpt! is really']"
       ]
      },
-     "execution_count": 261,
+     "execution_count": 267,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "topic_model.get_representative_docs(9)"
+    "topic_model.get_representative_docs(6)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Add topics to df"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 263,
+   "execution_count": 274,
    "metadata": {},
    "outputs": [
     {
@@ -3473,7 +3481,7 @@
        "    <tr style=\"text-align: right;\">\n",
        "      <th></th>\n",
        "      <th>topic</th>\n",
-       "      <th>document</th>\n",
+       "      <th>content</th>\n",
        "    </tr>\n",
        "  </thead>\n",
        "  <tbody>\n",
@@ -3538,7 +3546,7 @@
        "</div>"
       ],
       "text/plain": [
-       "       topic                                           document\n",
+       "       topic                                            content\n",
        "0          1  chatgpt on android is a solid app with seamles...\n",
        "1          6  i've been using chatgpt for a while but i've j...\n",
        "2         -1  the chatgpt android app has completely blown m...\n",
@@ -3554,14 +3562,385 @@
        "[21054 rows x 2 columns]"
       ]
      },
-     "execution_count": 263,
+     "execution_count": 274,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "df_topic = pd.DataFrame({\"topic\": topics, \"document\": docs})\n",
+    "df_topic = pd.DataFrame({\"topic\": topics, \"content\": docs})\n",
     "df_topic"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 272,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>Unnamed: 0</th>\n",
+       "      <th>reviewId</th>\n",
+       "      <th>userName</th>\n",
+       "      <th>content</th>\n",
+       "      <th>score</th>\n",
+       "      <th>thumbsUpCount</th>\n",
+       "      <th>at</th>\n",
+       "      <th>replyContent</th>\n",
+       "      <th>repliedAt</th>\n",
+       "      <th>appVersion</th>\n",
+       "      <th>at_ymd</th>\n",
+       "      <th>at_q</th>\n",
+       "      <th>at_ym</th>\n",
+       "      <th>at_m</th>\n",
+       "      <th>at_wd</th>\n",
+       "      <th>score_cat</th>\n",
+       "      <th>detected_language</th>\n",
+       "      <th>topic</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>0</td>\n",
+       "      <td>36b7f28e-151d-4b98-8a13-41bd017e0d25</td>\n",
+       "      <td>Lin Cheng</td>\n",
+       "      <td>chatgpt on android is a solid app with seamles...</td>\n",
+       "      <td>4</td>\n",
+       "      <td>5</td>\n",
+       "      <td>2023-10-19 19:26:19</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>1.2023.284</td>\n",
+       "      <td>10/19/23</td>\n",
+       "      <td>4</td>\n",
+       "      <td>2023-10</td>\n",
+       "      <td>October</td>\n",
+       "      <td>Thursday</td>\n",
+       "      <td>neutral</td>\n",
+       "      <td>en</td>\n",
+       "      <td>1</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>1</td>\n",
+       "      <td>2bc253b6-c804-47e9-b6f2-3a21027efab4</td>\n",
+       "      <td>Alim</td>\n",
+       "      <td>i've been using chatgpt for a while but i've j...</td>\n",
+       "      <td>5</td>\n",
+       "      <td>139</td>\n",
+       "      <td>2023-09-29 20:24:38</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>1.2023.263</td>\n",
+       "      <td>09/29/23</td>\n",
+       "      <td>3</td>\n",
+       "      <td>2023-09</td>\n",
+       "      <td>September</td>\n",
+       "      <td>Friday</td>\n",
+       "      <td>positive</td>\n",
+       "      <td>en</td>\n",
+       "      <td>6</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>2</td>\n",
+       "      <td>5f084727-ab85-40b3-bd42-a7a49502fc1f</td>\n",
+       "      <td>Theo Healy</td>\n",
+       "      <td>the chatgpt android app has completely blown m...</td>\n",
+       "      <td>4</td>\n",
+       "      <td>247</td>\n",
+       "      <td>2023-07-28 10:29:10</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>1.0.0023</td>\n",
+       "      <td>07/28/23</td>\n",
+       "      <td>3</td>\n",
+       "      <td>2023-07</td>\n",
+       "      <td>July</td>\n",
+       "      <td>Friday</td>\n",
+       "      <td>neutral</td>\n",
+       "      <td>en</td>\n",
+       "      <td>-1</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>3</td>\n",
+       "      <td>5df90de5-b8e2-4dc2-b6ff-520aa3a25eae</td>\n",
+       "      <td>Elliot Limberg</td>\n",
+       "      <td>no subscription free and accurate unbiased ans...</td>\n",
+       "      <td>5</td>\n",
+       "      <td>272</td>\n",
+       "      <td>2023-07-30 19:38:37</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>1.0.0023</td>\n",
+       "      <td>07/30/23</td>\n",
+       "      <td>3</td>\n",
+       "      <td>2023-07</td>\n",
+       "      <td>July</td>\n",
+       "      <td>Sunday</td>\n",
+       "      <td>positive</td>\n",
+       "      <td>en</td>\n",
+       "      <td>0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>4</td>\n",
+       "      <td>bb66c666-865d-4a31-b27f-4933df3ff829</td>\n",
+       "      <td>Phoebe Moraes</td>\n",
+       "      <td>i use this app for learning languages which ch...</td>\n",
+       "      <td>4</td>\n",
+       "      <td>126</td>\n",
+       "      <td>2023-08-09 18:23:33</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>1.0.0030</td>\n",
+       "      <td>08/09/23</td>\n",
+       "      <td>3</td>\n",
+       "      <td>2023-08</td>\n",
+       "      <td>August</td>\n",
+       "      <td>Wednesday</td>\n",
+       "      <td>neutral</td>\n",
+       "      <td>en</td>\n",
+       "      <td>1</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>...</th>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>127069</th>\n",
+       "      <td>30906</td>\n",
+       "      <td>d5b8ad76-8e43-48aa-9c65-65f9c6724259</td>\n",
+       "      <td>Pips Miner</td>\n",
+       "      <td>first rating</td>\n",
+       "      <td>5</td>\n",
+       "      <td>0</td>\n",
+       "      <td>2023-07-25 17:44:41</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>07/25/23</td>\n",
+       "      <td>3</td>\n",
+       "      <td>2023-07</td>\n",
+       "      <td>July</td>\n",
+       "      <td>Tuesday</td>\n",
+       "      <td>positive</td>\n",
+       "      <td>en</td>\n",
+       "      <td>-1</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>127070</th>\n",
+       "      <td>30909</td>\n",
+       "      <td>a9ea2b59-ca49-4ff1-a6c4-ff98141d0063</td>\n",
+       "      <td>Asokan Madhushan</td>\n",
+       "      <td>200th comment</td>\n",
+       "      <td>5</td>\n",
+       "      <td>0</td>\n",
+       "      <td>2023-08-01 05:23:56</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>08/01/23</td>\n",
+       "      <td>3</td>\n",
+       "      <td>2023-08</td>\n",
+       "      <td>August</td>\n",
+       "      <td>Tuesday</td>\n",
+       "      <td>positive</td>\n",
+       "      <td>en</td>\n",
+       "      <td>56</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>127071</th>\n",
+       "      <td>30911</td>\n",
+       "      <td>af93c4fc-330c-4e1a-906e-42cb2d530f6b</td>\n",
+       "      <td>Manish Kuntal</td>\n",
+       "      <td>beat response</td>\n",
+       "      <td>5</td>\n",
+       "      <td>0</td>\n",
+       "      <td>2023-07-27 05:08:17</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>07/27/23</td>\n",
+       "      <td>3</td>\n",
+       "      <td>2023-07</td>\n",
+       "      <td>July</td>\n",
+       "      <td>Thursday</td>\n",
+       "      <td>positive</td>\n",
+       "      <td>en</td>\n",
+       "      <td>112</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>127072</th>\n",
+       "      <td>30918</td>\n",
+       "      <td>0530373c-1bfc-45d2-9dec-9fc0bb9cff4d</td>\n",
+       "      <td>mostafijur rahman</td>\n",
+       "      <td>usually app</td>\n",
+       "      <td>5</td>\n",
+       "      <td>0</td>\n",
+       "      <td>2023-07-25 17:15:19</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>07/25/23</td>\n",
+       "      <td>3</td>\n",
+       "      <td>2023-07</td>\n",
+       "      <td>July</td>\n",
+       "      <td>Tuesday</td>\n",
+       "      <td>positive</td>\n",
+       "      <td>en</td>\n",
+       "      <td>0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>127073</th>\n",
+       "      <td>30921</td>\n",
+       "      <td>4775c835-38dd-48b8-8bf0-c3f38fe8794d</td>\n",
+       "      <td>Carter Gledhill</td>\n",
+       "      <td>first comment</td>\n",
+       "      <td>5</td>\n",
+       "      <td>0</td>\n",
+       "      <td>2023-07-25 21:05:55</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>07/25/23</td>\n",
+       "      <td>3</td>\n",
+       "      <td>2023-07</td>\n",
+       "      <td>July</td>\n",
+       "      <td>Tuesday</td>\n",
+       "      <td>positive</td>\n",
+       "      <td>en</td>\n",
+       "      <td>56</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "<p>127074 rows × 18 columns</p>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "        Unnamed: 0                              reviewId           userName  \\\n",
+       "0                0  36b7f28e-151d-4b98-8a13-41bd017e0d25          Lin Cheng   \n",
+       "1                1  2bc253b6-c804-47e9-b6f2-3a21027efab4               Alim   \n",
+       "2                2  5f084727-ab85-40b3-bd42-a7a49502fc1f         Theo Healy   \n",
+       "3                3  5df90de5-b8e2-4dc2-b6ff-520aa3a25eae     Elliot Limberg   \n",
+       "4                4  bb66c666-865d-4a31-b27f-4933df3ff829      Phoebe Moraes   \n",
+       "...            ...                                   ...                ...   \n",
+       "127069       30906  d5b8ad76-8e43-48aa-9c65-65f9c6724259         Pips Miner   \n",
+       "127070       30909  a9ea2b59-ca49-4ff1-a6c4-ff98141d0063   Asokan Madhushan   \n",
+       "127071       30911  af93c4fc-330c-4e1a-906e-42cb2d530f6b      Manish Kuntal   \n",
+       "127072       30918  0530373c-1bfc-45d2-9dec-9fc0bb9cff4d  mostafijur rahman   \n",
+       "127073       30921  4775c835-38dd-48b8-8bf0-c3f38fe8794d    Carter Gledhill   \n",
+       "\n",
+       "                                                  content  score  \\\n",
+       "0       chatgpt on android is a solid app with seamles...      4   \n",
+       "1       i've been using chatgpt for a while but i've j...      5   \n",
+       "2       the chatgpt android app has completely blown m...      4   \n",
+       "3       no subscription free and accurate unbiased ans...      5   \n",
+       "4       i use this app for learning languages which ch...      4   \n",
+       "...                                                   ...    ...   \n",
+       "127069                                       first rating      5   \n",
+       "127070                                      200th comment      5   \n",
+       "127071                                      beat response      5   \n",
+       "127072                                        usually app      5   \n",
+       "127073                                      first comment      5   \n",
+       "\n",
+       "        thumbsUpCount                   at replyContent repliedAt  appVersion  \\\n",
+       "0                   5  2023-10-19 19:26:19          NaN       NaN  1.2023.284   \n",
+       "1                 139  2023-09-29 20:24:38          NaN       NaN  1.2023.263   \n",
+       "2                 247  2023-07-28 10:29:10          NaN       NaN    1.0.0023   \n",
+       "3                 272  2023-07-30 19:38:37          NaN       NaN    1.0.0023   \n",
+       "4                 126  2023-08-09 18:23:33          NaN       NaN    1.0.0030   \n",
+       "...               ...                  ...          ...       ...         ...   \n",
+       "127069              0  2023-07-25 17:44:41          NaN       NaN         NaN   \n",
+       "127070              0  2023-08-01 05:23:56          NaN       NaN         NaN   \n",
+       "127071              0  2023-07-27 05:08:17          NaN       NaN         NaN   \n",
+       "127072              0  2023-07-25 17:15:19          NaN       NaN         NaN   \n",
+       "127073              0  2023-07-25 21:05:55          NaN       NaN         NaN   \n",
+       "\n",
+       "          at_ymd  at_q    at_ym       at_m      at_wd score_cat  \\\n",
+       "0       10/19/23     4  2023-10    October   Thursday   neutral   \n",
+       "1       09/29/23     3  2023-09  September     Friday  positive   \n",
+       "2       07/28/23     3  2023-07       July     Friday   neutral   \n",
+       "3       07/30/23     3  2023-07       July     Sunday  positive   \n",
+       "4       08/09/23     3  2023-08     August  Wednesday   neutral   \n",
+       "...          ...   ...      ...        ...        ...       ...   \n",
+       "127069  07/25/23     3  2023-07       July    Tuesday  positive   \n",
+       "127070  08/01/23     3  2023-08     August    Tuesday  positive   \n",
+       "127071  07/27/23     3  2023-07       July   Thursday  positive   \n",
+       "127072  07/25/23     3  2023-07       July    Tuesday  positive   \n",
+       "127073  07/25/23     3  2023-07       July    Tuesday  positive   \n",
+       "\n",
+       "       detected_language  topic  \n",
+       "0                     en      1  \n",
+       "1                     en      6  \n",
+       "2                     en     -1  \n",
+       "3                     en      0  \n",
+       "4                     en      1  \n",
+       "...                  ...    ...  \n",
+       "127069                en     -1  \n",
+       "127070                en     56  \n",
+       "127071                en    112  \n",
+       "127072                en      0  \n",
+       "127073                en     56  \n",
+       "\n",
+       "[127074 rows x 18 columns]"
+      ]
+     },
+     "execution_count": 272,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "df_merged = pd.merge(df, df_topic, on=\"content\")\n",
+    "df_merged"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 340,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df_merged.to_csv(\"../data/chatgpt_short_topics_wip.csv\")"
    ]
   },
   {
@@ -51240,13 +51619,6 @@
    "source": []
   },
   {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Add topics to df"
-   ]
-  },
-  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
@@ -54968,7 +55340,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Timeline"
+    "## Timeline / Deep-dive EDA"
    ]
   },
   {
@@ -54977,8 +55349,292 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "docs = list(df.content.values)\n",
-    "topic_model = BERTopic()"
+    "#docs = list(df.content.values)\n",
+    "#topic_model = BERTopic()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 334,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df_neg_top15 = df_merged[(df_merged[\"score_cat\"] == \"negative\") & (df_merged[\"topic\"]< 15)]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 313,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df_negative = df_merged[(df_merged[\"score_cat\"] == \"negative\") & (df_merged[\"topic\"] == 6)]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 285,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Index(['Unnamed: 0', 'reviewId', 'userName', 'content', 'score',\n",
+       "       'thumbsUpCount', 'at', 'replyContent', 'repliedAt', 'appVersion',\n",
+       "       'at_ymd', 'at_q', 'at_ym', 'at_m', 'at_wd', 'score_cat',\n",
+       "       'detected_language', 'topic'],\n",
+       "      dtype='object')"
+      ]
+     },
+     "execution_count": 285,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "df_negative.columns"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 314,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "7596    2023-07-25 17:17:30\n",
+       "9591    2023-07-25 17:22:33\n",
+       "2498    2023-07-25 17:37:55\n",
+       "9540    2023-07-25 19:05:41\n",
+       "9346    2023-07-26 06:10:46\n",
+       "                ...        \n",
+       "1174    2023-10-17 12:40:37\n",
+       "1476    2023-10-18 07:36:17\n",
+       "207     2023-10-20 04:01:11\n",
+       "27540   2023-10-21 13:15:15\n",
+       "9520    2023-10-21 15:18:35\n",
+       "Name: at, Length: 83, dtype: datetime64[ns]"
+      ]
+     },
+     "execution_count": 314,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "df_negative['at'] = pd.to_datetime(df_negative['at'])\n",
+    "df_negative['at'].sort_values()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 320,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df_negative[\"week_number\"] = df_negative['at'].dt.isocalendar().week"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 329,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>week_number</th>\n",
+       "      <th>reviewId</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>30</td>\n",
+       "      <td>17</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>31</td>\n",
+       "      <td>14</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>32</td>\n",
+       "      <td>3</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>33</td>\n",
+       "      <td>5</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>34</td>\n",
+       "      <td>3</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>5</th>\n",
+       "      <td>35</td>\n",
+       "      <td>4</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>6</th>\n",
+       "      <td>36</td>\n",
+       "      <td>4</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>7</th>\n",
+       "      <td>37</td>\n",
+       "      <td>3</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>8</th>\n",
+       "      <td>38</td>\n",
+       "      <td>4</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>9</th>\n",
+       "      <td>39</td>\n",
+       "      <td>6</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>10</th>\n",
+       "      <td>40</td>\n",
+       "      <td>6</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>11</th>\n",
+       "      <td>41</td>\n",
+       "      <td>8</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>12</th>\n",
+       "      <td>42</td>\n",
+       "      <td>6</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "    week_number  reviewId\n",
+       "0            30        17\n",
+       "1            31        14\n",
+       "2            32         3\n",
+       "3            33         5\n",
+       "4            34         3\n",
+       "5            35         4\n",
+       "6            36         4\n",
+       "7            37         3\n",
+       "8            38         4\n",
+       "9            39         6\n",
+       "10           40         6\n",
+       "11           41         8\n",
+       "12           42         6"
+      ]
+     },
+     "execution_count": 329,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "week_count = df_negative.groupby('week_number')['reviewId'].count().reset_index()\n",
+    "week_count"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 337,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAA1UAAAI6CAYAAADPKmL9AAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjcuMSwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy/bCgiHAAAACXBIWXMAAA9hAAAPYQGoP6dpAACZNUlEQVR4nOzdd3hT9f4H8PdJ0r13oS20jBZKKS17b5G9BCmIKChOHICA1+vPLRdBUUFwoIIgguwhQ/aUgmBboGzohu69m+T8/iiJlBboSHqS9P16nvt4SU5zPs03Sc873yWIoiiCiIiIiIiIakUmdQFERERERETGjKGKiIiIiIioDhiqiIiIiIiI6oChioiIiIiIqA4YqoiIiIiIiOqAoYqIiIiIiKgOGKqIiIiIiIjqgKGKiIiIiIioDhiqiIiIiIiI6oChisjILF26FAEBAXj66acfeExubu4jj9E3TZ0HDhyQrIbaUCqV+Oyzz9CjRw+0bdsWI0aMeOCxb7/9NgICAjBv3rwHHnP58mUEBATg7bff1ke5daJSqfDrr7+isLBQe5uU7ZaYmIiAgIAq/9emTRt07doVTz/9NLZt21Yv9Tz99NMICAhAbm5uvZzPGJ0+fdogXt8BAQEYNWqU3h7/+PHjeP3119GrVy8EBQWhT58+mDZtGnbv3g2lUqm389aWpl2q+7/ExET0798fHTt2lLp0IqOlkLoAIqqdM2fOYOPGjRg/frzUpZiUTZs24eeff4afnx/GjBkDFxeXR/7Mtm3bMGrUKHTv3r0eKtSd2bNnY8+ePRg5cqT2ts6dO2PGjBnw8/OTrC4vLy+MGTOmwm0lJSW4efMmjhw5gjNnziA1NRUvvPCCXusYM2YMOnfuDAsLC72eh+puxowZcHV11fnjlpSU4O2338bu3btha2uLPn36wMvLC+np6Th+/DhmzpyJ0NBQLF26FG5ubjo/f215eXlhxowZFW47c+YMzpw5gwEDBqB169YV7rO3t8eUKVNQWlpan2USmRSGKiIjtmjRIvTr108vFxMN1aVLlwAA7733Xo1C0vvvv4+dO3fC0tJSX6XpXEZGRqXbunTpgi5dukhQzb+8vLzw2muvVXnfX3/9hWnTpmH58uUICwuDvb293uoYO3as3h6bdOtBr5e6mjt3Lvbu3YvHH38cH330ERwdHbX3lZaW4quvvsJPP/2EyZMnY/v27Qbz/vf29q70nCxduhRnzpzBwIEDq3xtP/vss/VUHZFp4vA/IiMVGBiInJwcfPLJJ1KXYlI039Q6OTlV+2cCAwMRHx+PpUuX6qssuqt79+7o2LEjioqKEBERIXU5ZML279+PvXv3okOHDvjyyy8rBCoAMDc3x9y5czFu3DjExsZiyZIl0hRKRAaBoYrISE2fPh1+fn7Ys2cPDh8+/Mjjt2zZgoCAAKxatarSfffPHdHMbVm+fDn27duHMWPGIDg4GP3798fKlSsBAOfOncOkSZMQEhKC/v37Y+nSpVXOLSguLsb8+fPRrVs3hISE4Omnn8bp06errHHPnj0ICwtDaGgo2rdvj2eeeQbh4eEVjtHMFfjtt98wa9YsBAcHo2fPnjh37txDf/+TJ09i6tSpaN++PYKDgzFmzBisXbsWarW6wu+8detWAMDo0aMREBDwwFrvNWfOHDg5OWHVqlW4fPnyI48HAFEUsW7dOu1z26lTJ7z00kvanrJ7KZVKfP/993j88ccRHByMoUOHYtOmTVi+fLl2PoRGWVkZfvnlFzz55JPo0KEDgoKC0K9fP7z33nvIzMzUHhcQEIAzZ84AADp16qSdf3fvnKqysjJ06dIFvXr1giiKlep67733EBAQgPPnz2tvi46OxiuvvIIuXbogODgYo0aNwrp166r8+dpydnbW/q73iouLw1tvvYXu3bsjKCgIQ4YMwffff1/huJdeegkBAQG4detWpcfdtWsXAgICsGLFCgAPnlP1qNfpkSNHEBAQUOki+9ChQwgICMCkSZMq3J6dnY3WrVtj7ty5AMrb+5tvvsGIESMQEhKCzp0747nnnsOpU6eq/Rzt3r0bYWFhCAkJQWhoKMLCwrBr165Kx2nmQ/3zzz94+umnERoaik6dOuHNN9+s8LrSFbVajd9++w2jR49GcHAwOnTogKlTp+LkyZNVHr9+/XqMGDEC7dq1w4ABA7BixQps27at0nvz/jlVmtfxzZs3sXjxYvTt2xdBQUEYNmwY1q1bV61aV69eDaC8F0wulz/wuFmzZkGhUGDz5s0oKytDdHQ0AgICMGvWrCqPHzJkCDp16lRhqJ0+P/uq6/45VZq/GWfOnMEPP/yA/v37Izg4GKNHj8bx48cBlA+XHjJkCNq1a4cRI0Zg7969lR43Pz8fn3/+OQYOHIigoCD06tUL77//fpU95UTGjKGKyEiZm5vj448/hiAI+PDDD1FQUKDzc+zbtw+zZs1C8+bNMWHCBBQUFGDBggX45JNP8Oyzz8LJyQkTJ06EKIr45ptvsHbt2kqPsWDBAmzfvh1Dhw7F4MGDceHCBUydOhVHjhypcNzXX3+NN998E6mpqRgzZgzGjBmDGzduYOrUqdi+fXulx122bBkuXLiAyZMnIzAwEG3atHng77FmzRpMmzYNFy5cwGOPPYYnnngCeXl5+OijjzB79myIogh7e3vMmDEDrVq1AgBMmDABM2bMgJeX1yOfJycnJ/znP/+BUqnEu+++C5VK9cifmTdvHj744AOUlZUhLCwMgwcPxtmzZxEWFlbp4vnNN9/E4sWLYWFhgUmTJsHX1xf//e9/sWXLlkqPO3v2bMyfPx8KhQJPPvkkJkyYAHNzc/z++++YPn269rh7f7fp06dXmsMEAGZmZhgyZAhSU1MrXbgplUrs27cPvr6+CA4OBgAcPXoUYWFhCA8PR79+/TB58mSo1Wp88MEHeO+99x75nFRHUVERzp49C6D8QlojOjoaTzzxBPbu3YuuXbvi2WefhYODAxYvXoyXX35Z2yaa+WN79uyp9Ni7du2CIAgPXZykOq/TLl26wMLCotJFsebfFy5cQElJifb2kydPQq1Wo2/fvgCAjz/+GEuXLoWjoyOeeuopDB48GFFRUXjuueeqFfI/++wzzJw5E4mJiRg+fDiGDRuGxMREzJo1C4sWLap0fHR0NKZMmQKZTIaJEyciICAAe/bswbPPPqvTOTZqtRozZ87Ehx9+iPz8fDzxxBMYOHAgLly4gOeee67S58f8+fPx/vvvo7i4GOPHj0dISAi++uorfPPNN9U+55w5c7Bhwwb07t0bTz75JFJSUvDBBx9gw4YND/254uJiREREwMrKCp07d37osS4uLmjfvj2ys7Nx9uxZtGnTBs2bN8fhw4dRXFxc4djLly/j1q1bGDx4MMzNzQHo97NPF+bPn4+ff/4Z/fr1w7Bhw3Dt2jW8/PLL+OSTT/Dpp5+iffv2GDt2LBITEzFz5swKXwzl5eVh4sSJWLFiBby9vTFlyhSEhoZiw4YNGD9+PFJTU/VaO1G9EonIqCxZskT09/cX9+/fL4qiKP7f//2f6O/vL3788cfaY3JyckR/f39x8uTJ2ts2b94s+vv7iytXrqz0mJMnTxb9/f3FnJwcURRFMSEhQfT3969wHlEUxePHj2tv//XXX7W3a44fN25cpTo7deokJiQkaG+Pjo4W27VrJ/bt21dUKpWiKIpiVFSUGBAQIE6ePFksLCzUHpuZmSk+9thjYrt27cSMjAxRFEUxPDxc9Pf3F9u1ayempqY+8vmKj48XAwMDxb59+4rx8fHa2wsKCsQpU6aI/v7+4tatW7W3z5s3T/T39xcvXbr0yMe+/9hp06aJ/v7+4s8//6w95tKlS6K/v784b9487W27d+8W/f39xVmzZollZWUVau3cubPYq1cvsaSkRBRFUdy7d6/o7+8vvvLKK2Jpaan22F9//VXbFprnNyIiQvT39xdnz55doc6ysjJx+PDhor+/v3jr1i3t7fe3uyhWfn2dO3dO9Pf3Fz/88MMKj3n06FHR399fXLp0qSiKolhYWCh27dpV7NatW4X2VqlU4muvvSb6+/uLR44ceejzqXkd3fu61SgsLBTPnz+vfY7nzJmjvU+tVovDhw8X27ZtK164cKHCz82fP7/C67W4uFhs3769OGzYsArH5ebmikFBQRXOff/zU5PX6bRp08Q2bdqIBQUF2uNGjBghhoSEiP7+/uLp06e1t8+bN08MDAwUc3JyxLy8PLFVq1biU089VaG+8+fPi/7+/uJrr7320Ofw77//Fv39/cXRo0draxFFUczIyNC+Bs6cOaO9XfMaWrFiRYXnU/M8Hz169KHn07wf7319P8jWrVtFf39/cdq0aRWel/j4eLFHjx5iYGCg9j16/vx5MSAgQHzyySfF/Px87bGHDx/W1hweHl7h9xg5cqT235rXcb9+/So8D5rX8/jx4x9a67Vr10R/f39x+PDhj/y9RFEU33vvPdHf31/8/fffRVEUxW+//Vb09/cX9+zZU+G4RYsWVWh/fX723U/znGzevLnK+/v16yd26NBB+2/N34z27duLSUlJ2tu/+OIL0d/fX2zdurV4+fJl7e1btmwR/f39xYULF2pv++CDDyr9vRBFUTxw4IDo7+8vvv766zX+PYgMFXuqiIzcW2+9BTc3N6xduxZRUVE6fWwvLy8MHDhQ++/27dsDAKytrREWFqa93dvbG66urkhKSqr0GFOmTIG3t7f234GBgRg5ciRu376t7XHYtGkTRFHE3LlzYWVlpT3WyckJ06dPR1FRUaWehfbt21drta0dO3ZAqVTi1VdfhY+Pj/Z2a2trvPvuuwCAzZs3P/JxquODDz6AlZUVlixZ8tChU5s2bQIA/Pe//4VC8e96QT4+PggLC0NKSgr++usvANAOR5w3bx7MzMy0x06cOLHSCn2enp5YsGAB3njjjQq3KxQKdOjQAUDVi1M8TPv27eHj44M///yzQg+cpj00vTqHDh1CZmYmnnvuuQrtLZPJMHv2bADVf57PnDlTacnnkJAQjBs3DuHh4Rg3bhw+/PBD7fFRUVG4du0axo0bh6CgoAqP9cYbb8DMzEzbq2dhYYFBgwbh+vXruH79uva4AwcOoLS0tMJKiPeryeu0T58+KCsrw99//w0AyMzMxLVr1/Dkk08CgPZ2ADhx4gTat28Pe3t7qNVqiKKIO3fuIC0tTXtM27ZtceDAAXzxxRcPfe40v+fcuXO1wySB8iGTD2oHS0tLTJkyRftvQRDQq1cvAKjyPV1bmtfyBx98AGtra+3tPj4+ePnll6FUKrXL5W/fvh2iKOLNN9+EjY2N9ti+ffuiR48e1T7nE088UeF50DzPj/q98vLyAAC2trbVOo9mvlVWVhaA8veFIAjYvXt3heP27NmDRo0aoVOnTgD0+9mnK4MGDULjxo0rnB8AunXrpu3ZB6DtsdY8t5r2bNmyJZ566qkKjzlgwAC0b98e+/fvR35+vr5/BaJ6wdX/iIycvb09/u///g+vv/463n333SqHhNVW06ZNK/xbcyHk6elZaY6BhYVFlfv5aP4A3ys4OBi///47rly5gi5duiA6OhpA+XDD+4cFJicnA0CluUr3Xrg/zJUrVwBAexFzr5YtW8Le3l57TF35+Pjg9ddfx2effYYPPvgAP/74Y5XHRUdHw8LCosrhkjExMQDKf9++ffvi4sWLcHR0RJMmTSocJ5PJEBoaqj0eKG+XMWPGQKlUIjo6GjExMYiPj8fly5e1IU0zh6wmRowYgeXLl+PMmTPo1q0bSktLceDAAbRr1077Grl48aL2d6tqwQ65XF7t5/neJdXLyspw8uRJXLx4EYGBgVi2bFmFCzzNOQE8cLEQGxsbXL16FaIoQhAEjBw5Elu2bMHu3bu1AXTXrl0wNzfH448//sC6avI67dOnDz799FOEh4ejT58+OH36NERRxJgxY/DHH39ov1C4cuUK0tLSMHXqVADl7+ehQ4di165d6NevH0JDQ9G7d2/069cPLVq0eORzd+XKFchkMm2IvpfmtvvboXHjxtqhaBp2dnYAoNPhf1euXIGHh0eFLzceVNuFCxcA/Huhfq/27ds/cA7W/araGsDW1vaRF/IODg4AUGGY5sNo9nrTBDgvLy906NABR48eRUFBAWxsbBAVFYXExERMnz4dgiAAqNlrSqO6n326cv9njyb83V+HZusBzWsmJiYGhYWFUKlUVb4vS0pKoFKpcPXq1Spfr0TGhqGKyAQ8/vjjGDBgAA4ePIgff/yx0reCtXXvN6f3uv8C7GGq2udJ882z5kJE863wDz/88MDHycnJqfDv6u4dpLl40lwk3s/d3R1xcXHVeqzqeOaZZ/DHH3/g+PHj2LFjB1q2bFnpmLy8PO1iBA+i+X2zsrIeuGeUu7t7pdvWr1+PZcuWaecq2Nvbo127dmjevDmioqJqtWDEyJEjsXz5cuzZswfdunXDsWPHkJubW2HukaYNq1oM4f7f6VHuX1J91qxZ+Oyzz/Dzzz/jzTffxMqVKyv0XmjC/PHjx7UT6KtSUFAAW1tbdOnSBZ6entpQlZWVhVOnTqF///4PXaK9Jq/Tpk2bwtfXVzs/Ljw8HI6OjggICEDHjh1x7NgxKJVKHDt2DAC086mA8jlRQUFB2LJli3Zvoc8//xxBQUH45JNPKu0xdK/8/HxYWFhU+R61s7ODlZUVioqKKtxe1bGai/7avF4eVtuDtn/QvJY1c5CysrJgbW1doZ3vP7Y6HvS7Per3atSoERQKBeLj46FWqyGTPXxgz82bNwGgQuAfOXIkzp49i8OHD2P48OHa90ZV7xt9fPbpSm3/Dmjel7du3arWZx2RsWOoIjIR77//Pk6fPo1vv/22yuExD7tIuv8iS5c0Fw330lzwa74Ntra2hlwuR1RUVIUhbrqguShLSUmpMAxIIycnp9JSyXUhl8vxySefYNy4cfjf//6HxYsXVzpGc7F4/zfTVXnYt+r3375nzx68//77CAgIwPvvv482bdqgUaNGAMpfH7UdHurn54e2bdvizz//xPvvv489e/ZALpdj6NChFX4nAFi1ahW6detWq/M8zJw5c3Dp0iWEh4fj//7v/yo8r5pzf/rppxg3btwjH0smk2HYsGH46aefcOXKFURFRUGpVD50gQrNeWryOu3Vqxd+/fVXZGVl4cyZM+jUqRMEQUDnzp2xd+9eREdH48SJE/D29kbz5s21P2dmZoZp06Zh2rRpuH37Nk6ePIm9e/fixIkTePHFF3Hw4MEHnt/GxgZFRUXIzc2tFBBLSkpQXFxco+0CdMnGxgYpKSlV3qe5sNa8F21tbZGYmIiysrJKv2t9DBeztrZG9+7dcezYMZw+ffqhr+mcnBycO3cODg4OFXrEBw8ejE8++QR79uzBsGHDsHfvXvj7+1dYYEWfn31S03z2jho1CgsXLpS4GiL945wqIhPh4eGBWbNmoaSkBO+//36l+zV/sDW9QxqiKCIhIUFvdWmG8dwrMjISALTzXwICAqBSqapcjjwyMhKff/65drhUTWnG/Fe17HBcXBzS0tKq7E2qi8DAQDz77LPIzMys8mIiICAAycnJFebMaBw5cgRffvmldhhUmzZtkJycXOUqWfeHpD/++AMA8MUXX2DgwIHaQAVAu4R4bXseRo4ciezsbISHh+PQoUPo3r17hV5IzYWiZhjgvbKzs/Hpp59WuZJZdclkMvzvf/+DjY0Ndu3aVWGuysPOXVZWhgULFmDNmjWVfh8AOHjwIPbu3Qt7e/sKvUVVqenrtE+fPhBFEXv37sWtW7e0F9xdu3YFUN7W//zzT4XzJiQkYPHixdptEho3bozx48fjp59+QteuXZGSkvLQ+XoPe72fO3cOoihWaxihPrRq1Qp5eXm4du1apfs0z5umtjZt2kClUmmHx91L13NHH0SzzcDnn39eafn+ey1duhTFxcUYM2ZMhd4bBwcH9OnTB3/99RfCw8ORkpJSKbjr87NPan5+fjA3N0d0dHSVnzurVq3C8uXLtfPQiIwdQxWRCZk0aRJCQ0Or3OuoWbNmAMqHSN274MBvv/2G7OxsvdW0Zs2aCvsjnT17Fnv37kXLli218yU082fmz59f4Vvo/Px8fPDBB1ixYkW1limvyqhRo6BQKPDdd99VCI+FhYX46KOPtMfo2muvvQYfH58q22LMmDEQRREff/xxhTkrqampeP/99/HDDz9ov+UdO3YsRFHEwoULKzwH27dvrxRYNcOC0tPTK9y+bds27Z5U9+4lpgnaD7tg1Bg2bBgUCgUWLlyIwsLCSgs6PPbYY7C1tcWPP/5YYZ4XACxatAirV69GfHz8I8/zMI0bN8bMmTMBlL9WNMOLOnXqBG9vb2zatKnShsA//PADVq5cWenivFWrVvD398fu3btx5swZPP74448czlTT12mXLl1gZWWl3feqS5cuAIDmzZvD1dUVa9asQVlZWYVQZWlpiRUrVuDrr7+u8NooLS1FWloazM3NH7pIwdixYwEAixcvrvC+uzfg6+P1Xh2a2j799NMKX+4kJCRg2bJlMDMzw7Bhwyoc++WXX1boSQ8PD8eBAwfqpd7evXtjzJgxuHjxIl577bVKF/9KpRJff/011qxZA19f30oLxADl4b2wsBALFiyocrl+fX72Sc3CwgJDhw7FjRs3tPsbapw+fRoLFy7E5s2btSMWiIwdh/8RmRBBEPDJJ59g9OjRlS6UNfuZREREYNKkSejUqROuXr2K8PBwtGvXTm/f/ioUCowaNQpDhw5FRkYG9u7dC0tLS/zvf//THtO1a1c8/fTTWLNmDYYNG4Y+ffrA3NwcBw4cwJ07dxAWFqa9IK0pHx8fzJs3D59++inGjBmDgQMHwtraGseOHUNCQgKGDRuG0aNH6+i3/ZeVlRU+/PBDTJs2rdJ9Y8eOxaFDh/Dnn3/i6tWr6NWrF5RKJfbs2YPs7GzMnj1bO5l/2LBh2L59O3bu3IkbN26gS5cuiIuLw5EjR+Dk5ISsrCztoiEjR47Erl27MGPGDAwbNgy2tra4cOECzpw5AxcXF2RkZFQI0B4eHgCAd955Bz169KiwAtz9XFxctMOhrK2tK6wKCZTP3frkk0/w1ltvaZ9nd3d3/P333zh//jzatm1b5XNRU0899ZQ2UH7++ef46KOPIJfL8dlnn2H69OmYPHkyBgwYAB8fH1y8eBHh4eHw9vauciPWkSNH4vPPPweARw79A2r+OjU3N0fXrl1x+PBh7XwqjU6dOmHPnj2wtrau8DNubm545plnsHLlSgwfPhx9+vSBTCbD8ePHcfPmTbzyyisPXZGuU6dOmDp1KlauXImRI0eiX79+AIDDhw8jLS0N06dPr3LRlro6fvy4tmfnfu3bt8fMmTMxatQo7et+5MiR6N27NwoLC3Hw4EHk5+fj3Xff1S6KoNmweP369Rg9ejR69eqFjIwM7Nu3D3Z2dhVe9/r08ccfw8zMDBs2bMBjjz2GPn36wMvLC9nZ2Thx4gSSkpIQHByMr7/+usKKhhp9+/bVLobTuXPnCr3HgH4/+wzBvHnzEBERgc8++wwHDx5EcHAwUlJSsG/fPigUCsyfP/+R89WIjAVDFZGJadGiBV544QUsW7as0n3ff/89vvjiCxw+fBhXr15FUFAQfvnlF+zZs0dvoWr+/PnYvn07tmzZAqVSiR49emD27Nnw9/evcNy7776Ltm3bYt26ddixYwfkcjn8/Pzw2muvVbkxbU1MmTIFvr6++Omnn7Bv3z6IoojmzZvjxRdfrNYcnNrq0aMHRo8erV0mWkMQBCxZsgRr167Fli1bsHHjRlhaWqJFixaYOnVqhcAiCAKWLl2Kb7/9Fjt27MDatWvRtGlTLFy4EIcOHcKePXtgaWkJoPwC7ssvv8SKFSuwc+dOWFpawsfHB++99x5CQ0MxZswYHD16FMOHDwcAvPTSS7h58yZOnjyJ2NjYh4YqoDyEHDt2DP3796/yAnLIkCHw9PTE999/j+PHj6OoqAheXl545ZVX8Nxzz1W56EBNyWQyfPzxxxg3bhw2bNiAkSNHomPHjujYsSM2btyIb7/9FqdOncLhw4fh6emJp59+Gi+99FKVCySMGDECixcvhru7e7WDRk1fp71798bhw4fRsWNH7bxGoLzXas+ePejatWulHrI5c+agadOm2LhxI7Zu3QqVSoUWLVpgwYIF1XovvP322wgMDMTatWuxc+dOKBQKtG7dGu+99x4GDRpUrd+zptLT0yv1kGpoFokRBAFfffUV1q5di02bNmHTpk2wsrJCSEgInnvuOe2wSI333nsPTZo0wYYNG7B+/Xp4eHhgzpw5SEtLw48//qh93euTmZkZPv74Y4wePRpr167FhQsXsH//fjg4OMDf3x9vvvkmhgwZ8sD5UObm5hg8eDA2bNjwwOCuz88+qTk7O2PDhg34/vvvsX//fqxZswbOzs7o378/XnnllQpLshMZO0HU5dI+RESkU3fu3IGdnV2VvROTJ0/GxYsXERERUeGCncjYpaWlwczMrMpFZObNm4dt27bhr7/+qnJ1USIiKbDPlYjIgK1YsQIdOnTQzonSiIiIwLlz59C5c2cGKjI5O3bsQJcuXbQbBmvEx8dj//79aNGiBQMVERkU9lQRERmw6OhoTJgwAWZmZhg0aBA8PDyQmJiIAwcOwNzcHL///nuF5biJTEFycjJGjBiBoqIiDBgwAE2aNEF6ejr27duH0tJSrFixotJwQSIiKTFUEREZuEuXLuH7779HZGQkMjIy4OzsjO7du+OVV17RTuwnMjVxcXH4/vvvER4ejrS0NNjb26NDhw548cUX0aZNG6nLIyKqgKGKiIiIiIioDjinioiIiIiIqA4YqoiIiIiIiOqAoYqIiIiIiKgOuPnvfURRhFptGNPMZDLBYGoh3WG7mh62qWliu5oetqlpYruaHkNpU5lMqPa2JQxV91GrRWRmFkhdBhQKGZycbJCbWwilUi11OaQjbFfTwzY1TWxX08M2NU1sV9NjSG3q7GwDubx6oYrD/4iIiIiIiOqAoYqIiIiIiKgOGKqIiIiIiIjqgKGKiIiIiIioDhiqiIiIiIiI6oChioiIiIiIqA4YqoiIiIiIiOqAoYqIiIiIiKgOGKqIiIiIiIjqgKGKiIiIiIioDhiqiIiIiIiI6oChioiIiIiIqA4YqoiIiIiIiOqAoYqIiIiIiKgOGKqIiIiIiIjqgKGKiIiIiIioDhiqiIiIiIiI6oChioiIiIiIqA4YqgzUuaupeOq9PThzKUXqUoiIiIiI6CEYqgxUYbESuQWl+Hn3ZWTnl0hdDhERERERPQBDlYHq3tYTLbwdUFisxJo/r0IURalLIiIiIiKiKjBUGSi5TIbXJ4RCLhMQcT0df19JlbokIiIiIiKqAkOVAfNr7IARPXwBAGv3X0NeYam0BRERERERUSUMVQZuZE8/eLnaIK+wDOsOXpe6HCIiIiIiug9DlYFTyGWYOrQ1BAEIj05B1I10qUsiIiIiIqJ7MFQZgWaN7TGokw8AYPWfV1FYrJS4IiIiIiIi0mCoMhKjezWDu5MVsvJKsPHIDanLISIiIiKiuxiqjISFmRxTh7QCAByNvI3LcVkSV0RERERERABDlVEJaOKEvqFeAIBVey6jpFQlcUVERERERMRQZWTG920OZ3sLpGUXY+vxW1KXQ0RERETU4DFUGRkrCwWmPF4+DHD/3wm4mZQjcUVERERERA0bQ5URCm7ugm5tPCEC+Hn3ZZQp1VKXRERERETUYDFUGamJA1vC3toMdzIKsfOvWKnLISIiIiJqsBiqjJStlRkmDwoAAOwJj0N8Sp7EFRERERERNUwMVUasYyt3dPB3g0otYuXuK1CpOQyQiIiIiKi+MVQZucmD/GFjqUBcSh72no6XuhwiIiIiogaHocrIOdhaIGxASwDA9hOxuJNRIHFFREREREQNC0OVCege5ImgZs5QqtRYuecK1KIodUlERERERA0GQ5UJEAQBzzzeChbmctxIzMGhc4lSl0RERERE1GAwVJkIFwdLjO/bHACw+egtpGcXSVwREREREVHDwFBlQvqGesHfxxElZSqs2nsFIocBEhERERHpHUOVCZEJAqYOaQUzhQyXYrNw4vwdqUsiIiIiIjJ5Bh+qfvjhB/To0eOB92/evBmjRo1CcHAwBgwYgMWLF6O4uLgeKzQsHs7WGN3LDwCw/tANZOWVSFwREREREZFpM+hQdfToUSxZsuSB9y9fvhzvvPMOGjVqhHfeeQddunTB999/j3feeaceqzQ8gzr5wNfTDkUlSvy67yqHARIRERER6ZFBhipRFPHrr7/i1VdfRVlZWZXHxMbGYvny5RgyZAi+/fZbhIWFYf78+ZgyZQp27dqFmzdv1nPVhkMuk2Ha0NaQywREXE/H31dSpS6JiIiIiMhkKaQuoCoTJkxAVFQUevbsiaysLKSkpFQ6Zvv27SgrK8OcOXMgCIL29kmTJsHGxqbB9854u9tiWLem2HEyFmv3X0Prpk6wszaXuiwiIiIiIpNjkD1Vt2/fxkcffYQff/wRNjY2VR5z9uxZ+Pn5wcvLCwBQXFwMpVIJPz8/vPnmm2jRokV9lmyQhnf3hZebDfIKy7DuwHWpyyEiIiIiMkkGGaoOHTqECRMmVOiBul9MTAy8vLxw8uRJjBo1Cu3atUNoaCjmzp2LvLy8eqzWcCnk5cMABQEIv5SCyBvpUpdERERERGRyDHL4n7n5o4ep5eXlITY2Fq+88gomT56MGTNm4OzZs1i9ejUSExOxZs0ayOXyWp1foZA+a8rlsgr/ra2WPo4Y3KUp9oTHYc2fVxHo6wxrS4Ns9gZBV+1KhoNtaprYrqaHbWqa2K6mx1jb1GivrktLS5GYmIj33nsPTz31FADgscceg52dHZYuXYqDBw9i0KBBNX5cmUyAk1PVQw6lYG9vVefHmDYqCJE30nEnvQBbT8RgxviQuhdGdaKLdiXDwjY1TWxX08M2NU1sV9NjbG1qtKHKysoKRUVFGDduXIXbx4wZg6VLl+L06dO1ClVqtYjc3EJdlVlrcrkM9vZWyM0tgkqlrvPjTR3SCvPXnMOf4XEIbe6CQD9nHVRJNaXrdiXpsU1NE9vV9LBNTRPb1fQYUpva21tVu8fMaEOVp6cnUlNTYWFhUeF2FxcXAEBBQUGtH1upNJw3pUql1kk9Lbwc0C/UC4cjkvDjH5fw8XNdYGFeu+GRVHe6alcyHGxT08R2NT1sU9PEdjU9xtamxjVY8R5t2rRBXl5epeXWExISAACNGjWSoiyDNq5vczjbWyA9pxhbjt2SuhwiIiIiIpNgtKFqxIgRAIAVK1ZUuH3lypUAyudXUUVWFgo8M7gVAODA2QTcSMqRuCIiIiIiIuNntMP/evfujeHDh2PNmjXIyMhAly5dcOrUKezduxcTJ05EYGCg1CUapLbNXNA9yBN/XUzGyt2X8cHUzjAzgNUOiYiIiIiMldGGKgD47LPP0KpVK2zatAn79+9H48aNMW/ePEydOlXq0gxa2ICWuBiTiTsZhdj5VwzG9m4udUlEREREREZLEEVRlLoIQ6JSqZGZWftFLnRFoZDByckGWVkFepmkd/ZKKpZvuwiZIOC9ZzuiiYedzs9Blem7Xan+sU1NE9vV9LBNTRPb1fQYUps6O9tUe/U/jvtqoDq2ckeHADeoRRE/774MJZchJSIiIiKqFYaqBmzyY/6wsVQgPiUff56Jl7ocIiIiIiKjxFDVgDnYWiBsQEsAwPYTsbiTIf2wRyIiIiIiY8NQ1cB1D/JEUDNnKFVqrNx9BWo1p9gREREREdUEQ1UDJwgCnnm8FSzM5biRlIOD/yRKXRIRERERkVFhqCK4OFjiyb7ly6pvPnoTadlFEldERERERGQ8GKoIANAn1Av+Po4oLVPjl71XwJX2iYiIiIiqh6GKAAAyQcDUIa1gppDhUmwWjp+/I3VJRERERERGgaGKtDycrTGmVzMAwO+HbiArr0TiioiIiIiIDB9DFVXwWCdv+DWyQ1GJEmv+vMphgEREREREj8BQRRXIZTJMHdoacpmAyBvpOHM5VeqSiIiIiIgMGkMVVeLtZovh3X0BAGv3X0NuYam0BRERERERGTCGKqrSsG5N4e1mg/yiMqw7cF3qcoiIiIiIDBZDFVVJIS8fBigIwOlLKYi8ni51SUREREREBomhih7Ir5E9Hu/cBACw+s8rKCwuk7giIiIiIiLDw1BFDzW6px88nKyQnV+KDYdvSF0OEREREZHBYaiihzI3k+PZIa0AAMei7uBSbKbEFRERERERGRaGKnqkgCZO6NfeCwCwas8VlJSqJK6IiIiIiMhwMFRRtYzr0xwu9hZIzynG5mM3pS6HiIiIiMhgMFRRtVhZKPDM4PJhgAfPJuJGYo7EFRERERERGQaGKqq2oGYu6BHkCRHAyj2XUabkMEAiIiIiIoYqqpEJA1rC3sYcdzIKseNkrNTlEBERERFJjqGKasTWygxPD/IHAOwJj0dccp7EFRERERERSYuhimqsQ4A7Oga4QS2KWLn7MpQqtdQlERERERFJhqGKauWpQQGwsVQgPjUfe0/HS10OEREREZFkGKqoVhxszDFxYEsAwI6TMbidXiBxRURERERE0mCoolrr1sYTbZu5QKkSsXLPZajVotQlERERERHVO4YqqjVBEPDM4ABYmstxMykXB88lSl0SEREREVG9Y6iiOnG2t8T4fi0AAJuP3URqdpHEFRERERER1S+GKqqzPiGNEeDjiNIyNX7ZcwWiyGGARERERNRwMFRRnckEAc8ObQVzhQyX47Jw/PwdqUsiIiIiIqo3DFWkEx5O1hjdqxkA4PdD15GVVyJxRURERERE9YOhinRmUCcf+DWyR1GJCmv+vMphgERERETUIDBUkc7IZAKmDW0FuUxA5I10nL6cInVJRERERER6x1BFOuXlZosR3X0BAL/tv47cwlJpCyIiIiIi0jOGKtK5od2awtvNBvlFZfht/zWpyyEiIiIi0iuGKtI5hVyGqUNbQxCAM5dTEXE9TeqSiIiIiIj0hqGK9MKvkT0Gd24CAFj951UUFpdJXBERERERkX4wVJHejOrpBw8nK+Tkl+L3QzekLoeIiIiISC8YqkhvzM3kmDq0NQDg+Pk7iI7NlLgiIiIiIiLdY6givfL3cUT/9l4AgF/2XEFxqVLiioiIiIiIdIuhivTuiT7N4WJvgfScYmw5ekvqcoiIiIiIdIqhivTOykKBZ4a0AgAcPJeI64nZ0hZERERERKRDDFVUL4L8XNCjrSdEACt3X0GZUiV1SUREREREOsFQRfUmbEBLONiYIzmzEDtOxkpdDhERERGRThh8qPrhhx/Qo0ePRx6nVCoxduxY9O/fvx6qotqwsTTD5EEBAIA94fGIS86TuCIiIiIioroz6FB19OhRLFmypFrHfvfdd4iOjtZzRVRXHQLc0LGVO9SiiJW7L0OpUktdEhERERFRnRhkqBJFEb/++iteffVVlJWVPfL4S5cu4bvvvoOZmVk9VEd19dRj/rCxVCA+NR97TsdLXQ4RERERUZ0YZKiaMGECPv74Y3Tp0gVt2rR56LGlpaV4++230bNnTwQGBtZThVQXDjbmmDTQHwCw82QMktILJK6IiIiIiKj2DDJU3b59Gx999BF+/PFH2NjYPPTYZcuWITk5GR999FE9VUe60LWNB4Kbu0CpErFq92Wo1aLUJRERERER1YpBhqpDhw5hwoQJEAThocedP38eK1aswDvvvAN3d/d6qo50QRAETHk8AJbmcty8nYsD5xKlLomIiIiIqFYUUhdQFXNz80ceU1JSgrfffhu9e/fG6NGjdXp+hUL6rCmXyyr81xS5O1sjbEBLrNpzBVuO3kT3tp5wtLWQuiy9agjt2tCwTU0T29X0sE1NE9vV9BhrmxpkqKqOr776CmlpaVi5cqVOH1cmE+Dk9PAhh/XJ3t5K6hL0akx/fxyOSEJcch6SMovg5+MsdUn1wtTbtSFim5omtqvpYZuaJrar6TG2NjXKUBUREYFVq1Zh7ty5MDMzQ2ZmJoDyvarUajUyMzNhYWHxyPlYVVGrReTmFuq65BqTy2Wwt7dCbm4RVCa+7Livpx3ikvNw5VYG2jRxlLocvWpI7dpQsE1NE9vV9LBNTRPb1fQYUpva21tVu8fMKEPViRMnoFarsWDBAixYsKDS/d26dcOYMWOqvK86lErDeVOqVGqDqkcfGruUh9/4lDyT/101GkK7NjRsU9PEdjU9bFPTxHY1PcbWpkYZqkaPHo0OHTpUuv2TTz5BTk4OFi1axIUrjIi3uy0AIDEtX+JKiIiIiIhqzihDlY+PD3x8fCrdbmtri+LiYnTv3l2Cqqi2vN3Ke6rSsotRVKKElYVRviyJiIiIqIEyrmU1yCTZWZvDwbZ8xcfb3AiYiIiIiIwMQxUZBG+38iGACRwCSERERERGxuDHWa1Zs6bax27YsEGPlZA++bjZIjomE0mp7KkiIiIiIuPCnioyCF5351Wxp4qIiIiIjA1DFRkEH80KgKn5EEVR4mqIiIiIiKqPoYoMQiMXG8gEAYUlSmTllUhdDhERERFRtTFUkUEwU8jg6WINgPtVEREREZFxYagig6HZryoxjYtVEBEREZHxYKgig6FZVj0xlT1VRERERGQ8GKrIYHhrFqvg8D8iIiIiMiIMVWQwNMP/7mQUQqlSS1wNEREREVH1MFSRwXCxt4SVhRwqtYjkjEKpyyEiIiIiqhaGKjIYgiDA6+68Km4CTERERETGgqGKDIqPG+dVEREREZFxYagig6JdVj2Vy6oTERERkXFgqCKDwhUAiYiIiMjYMFSRQfFyLQ9VWXklyC8qk7gaIiIiIqJHY6gig2JtqYCLvSUAIIm9VURERERkBBiqyOD4aIcAcl4VERERERk+hioyOF53F6tISGVPFREREREZPoYqMjianioO/yMiIiIiY8BQRQbHy+3f4X9qUZS4GiIiIiKih2OoIoPj6WwFhVxASZkK6TnFUpdDRERERPRQDFVkcOQyGRq7aDYB5hBAIiIiIjJsDFVkkLSbADNUEREREZGBY6gig+StnVfFUEVEREREho2higySt/vdZdW5VxURERERGTiGKjJIPnd7qlKzClFSppK4GiIiIiKiB2OoIoNkb2MOWysziCJwO529VURERERkuBiqyCAJgqDdBJjzqoiIiIjIkDFUkcHyctMsq86eKiIiIiIyXAxVZLB8uAIgERERERkBhioyWN4c/kdERERERoChigxWY1cbCADyCsuQU1AqdTlERERERFViqCKDZWEmh7uTFQAgMZW9VURERERkmBiqyKBphgAmMFQRERERkYFiqCKD5n13sYokzqsiIiIiIgPFUEUGTROqEhiqiIiIiMhAMVSRQfNxL9+r6nZ6IVRqtcTVEBERERFVxlBFBs3V0QoWZnIoVWqkZBZJXQ4RERERUSUMVWTQZIIAL7fy3iruV0VEREREhoihigyeN0MVERERERkwhioyeJrFKhJTCySuhIiIiIioMoYqMnjaUMWeKiIiIiIyQAxVZPA0GwCn5xSjqEQpcTVERERERBUxVJHBs7Uyg6OtOQAgKY1DAImIiIjIsDBUkVHQ9FZxE2AiIiIiMjQMVWQUOK+KiIiIiAyVwYeqH374AT169KjyvrS0NPznP/9Bz549ERQUhAEDBuDLL79EaWlpPVdJ+uajXQGQoYqIiIiIDItC6gIe5ujRo1iyZAkcHBwq3VdcXIxnnnkGiYmJmDRpEpo2bYqzZ8/iu+++w7Vr1/Dtt99KUDHpi2b4X2JaAURRhCAIEldERERERFTOIEOVKIpYu3YtFixYgLKysiqP+fXXX3Hz5k18++236N+/PwBg4sSJaNSoEVasWIHw8HB07dq1PssmPWrkYg25TEBRiRKZuSVwcbCUuiQiIiIiIgAGOvxvwoQJ+Pjjj9GlSxe0adOmymPCw8Ph5OSkDVQaw4cPBwCcO3dO73VS/VHIZfB0sQbAeVVEREREZFgMMlTdvn0bH330EX788UfY2NhUecyCBQuwZs2aSrdnZmYCABQKg+yEozrgYhVEREREZIgMMnkcOnQI5ubmDz3G1dUVrq6ulW5fvXo1AKBDhw56qY2k4+1mg9Mon1dFRERERGQoDDJUPSpQPci6detw+PBhdOrUCR07dqz1+RUK6Tvw5HJZhf8S0NTTHkB5T5UhtFFtsF1ND9vUNLFdTQ/b1DSxXU2PsbapQYaq2ti+fTs++ugjuLm5YeHChbV+HJlMgJNT1UMOpWBvbyV1CQYjqGX5mys5oxC2dpYwU8glrqj22K6mh21qmtiupodtaprYrqbH2NrUJELVmjVrMH/+fDg6OuKnn35C48aNa/1YarWI3NxCHVZXO3K5DPb2VsjNLYJKpZa6HIMgF0VYWyhQWKLEpRtpaOJhJ3VJNcZ2NT1sU9PEdjU9bFPTxHY1PYbUpvb2VtXuMTP6ULVkyRIsW7YMHh4eWLlyJZo3b17nx1QqDedNqVKpDaoeqXm72eBaYg5i7+SisYvh9CjWFNvV9LBNTRPb1fSwTU0T29X0GFubGtdgxft88803WLZsGZo2bYrffvtNJ4GKDJvXPZsAExEREREZAqPtqTp+/DiWLl0KHx8f/Prrr3B3d5e6JKoHPppl1VO5rDoRERERGQajDVWaxSj69euHU6dOVbrf398frVu3ru+ySM+83blXFREREREZFqMMVZmZmbh27RqAf/elut/06dMZqkyQl2v5PKrs/FLkF5XB1spM4oqIiIiIqKEz+FC1Zs2aSrc5Ozvj6tWrElRDUrOyUMDVwRLpOcVITM1Hq6ZOUpdERERERA2cUS9UQQ2T9915VQkcAkhEREREBoChioyOZl5VEkMVERERERkAhioyOt5u5fOqElK5rDoRERERSY+hioyOj6anKj0falGUuBoiIiIiaugYqsjouDtZQSGXobRMjbTsIqnLISIiIqIGjqGKjI5cJtMurc5NgImIiIhIagxVZJS83e+GqjTOqyIiIiIiaTFUkVHSLKvOnioiIiIikhpDFRklzbLqiVxWnYiIiIgkxlBFRknTU5WaVYSSUpXE1RARERFRQ8ZQRUbJwcYc9tZmEAHczuC8KiIiIiKSDkMVGS2vu71VCZxXRUREREQSYqgio+XDeVVEREREZAAYqshoeblxryoiIiIikh5DFRmtf3uqCiCKosTVEBEREVFDxVBFRquxiw0EAcgvKkNOQanU5RARERFRA8VQRUbL3EwODydrABwCSERERETSYagio+Z9zxBAIiIiIiIpMFSRUfO+u1gFl1UnIiIiIqkwVJFR87m7V1USl1UnIiIiIokwVJFR87o7/O92RgGUKrXE1RARERFRQ8RQRUbN1cESFuZyKFUiUrKKpC6HiIiIiBoghioyajJBgLcrNwEmIiIiIukwVJHR+3cFQIYqIiIiIqp/DFVk9LzvLlbBnioiIiIikgJDFRk9zbLq7KkiIiIiIikwVJHR0wz/y8gtQWGxUuJqiIiIiKih0WuoKi0tRWxsrD5PQQQbSzM42VkAYG8VEREREdW/Woeq1q1bY9myZQ895ptvvsH48eNrewqiavNx5ybARERERCQNRXUPvHjxIlJSUrT/FkURt27dwsGDB6s8vqysDEeOHIFSyeFYpH9ebjY4fzMDCWkFUpdCRERERA1MtUNVTk4OXn31VQiCAAAQBAG7d+/G7t27H/gzoihi6NChda+S6BF83LisOhERERFJo9qhqkePHnjvvfeQmZkJURSxbNkydOrUCV26dKnyeDMzM3h4eDBUUb3QLKuelJYPURS14Z+IiIiISN+qHaoAYNKkSdr/f+bMGTzxxBMYPXq0rmsiqjFPF2vIZQKKSlTIyC2Gq4OV1CURERERUQNRo1B1rzVr1uiyDqI6UchlaORijcS0AiSmFjBUEREREVG9qXWoAoCsrCzs27cPSUlJKC0thSiKlY4RBAFvv/12XU5DVC3e7rbloSotHyEtXaUuh4iIiIgaiFqHqitXruCZZ55Bbm5ulWFKg6GK6kv5vKoULlZBRERERPWq1qFq8eLFyMnJwZNPPonevXvDzs6OiwOQpDSLVSSkMlQRERERUf2pdag6e/Ys+vXrh48++kiX9RDVmrebDQAgJbMIZUoVzBRyiSsiIiIiooZAVusflMnQrFkzXdZCVCdOdhawsVRALYq4nV4odTlERERE1EDUOlR17NgRZ8+e1WUtRHUiCIJ2CCDnVRERERFRfal1qJozZw5iYmLwySefICUlRZc1EdUaQxURERER1bdaz6n68MMP4eDggLVr12Lt2rWwsLCAubl5peMEQcDp06frVCRRdXm7l8+rSkwrkLgSIiIiImooah2qEhMTAQCNGjXSWTFEdaXtqeIKgERERERUT2odqg4dOqTLOoh0wuvuCoA5BaXILSyFvXXl3lMiIiIiIl2q9ZwqIkNkaa6Am6MlACCJvVVEREREVA9q3VN18ODBah87YMCA2p4GP/zwA3755RecPHmy0n3FxcX45ptvsGvXLmRmZqJVq1Z488030a1bt1qfj4yft5st0rKLkZBWgNa+zlKXQ0REREQmrtah6tVXX4UgCNU69vLly7U6x9GjR7FkyRI4ODhUef/s2bNx+PBhTJo0Cc2aNcOmTZvw/PPP45dffkHHjh1rdU4yft5utoi4ns4VAImIiIioXug8VBUVFSE+Ph5Hjx5Fu3bt8Mwzz9T4sUVRxNq1a7FgwQKUlZVVecypU6dw4MAB/Oc//8Gzzz4LABg9ejRGjhyJ+fPnY8uWLTU+L5kGH3cuVkFERERE9afWoeq111576P2XLl3CpEmTkJeXV+PHnjBhAqKiotCzZ09kZWVVuQ/Wzp07YWZmhieffFJ7m7W1NcaNG4cvv/wSsbGx8PX1rfG5yfhpFqu4nV4AtVqETFa9HlUiIiIiotrQ20IVgYGBGDx4MH7++eca/+zt27fx0Ucf4ccff4SNjU2Vx1y8eBF+fn6wtraucHubNm2091PD5OFkDTOFDKVKNVKzi6Quh4iIiIhMXK17qqrDyckJcXFxNf65Q4cOVbmR8L1SUlIQHBxc6XZ3d3cA5cGMGiaZTICXqw1ik/OQmJoPT2frR/8QEREREVEt6S1UZWZm4s8//4Sbm1uNf/ZRgQoACgoKYGVlVel2S8vy5bSLimrfQ6FQSL/SvFwuq/BfqhkfD1vEJufhdkaBQbSnBtvV9LBNTRPb1fSwTU0T29X0GGub1jpUzZgxo8rb1Wo1ioqKcP78eRQWFuLVV1+tdXF1Ud2VCe8nkwlwcqp6yKEU7O0rB0d6tABfFxyPuoOU7GKDak8NtqvpYZuaJrar6WGbmia2q+kxtjatdag6cODAQ+93cHDAs88+i5dffrm2p3goa2trFBcXV7pdc5utrW2tHletFpGbW1in2nRBLpfB3t4KublFUKnUUpdjdFxsy3s7byZmIyurQOJq/sV2NT1sU9PEdjU9bFPTxHY1PYbUpvb2VtXuMdP55r+CIMDMzAwuLi6QyfTXbde4cWOkpaVVuj01NRUA4OHhUevHVioN502pUqkNqh5j0cilfB5VWlYR8gtLYWmu1+mDNcZ2NT1sU9PEdjU9bFPTxHY1PcbWprW+0vTy8tJlHTXWpk0b7NixA8XFxdp5VAAQHR0NAGjbtq1UpZEBsLc2h72NOXILSpGUXoDmjaveQJqIiIiIqK7q/PX92bNnsXnzZly9ehVFRUVwdHREy5YtMXLkSHTs2FEXNVZp8ODB2LRpE9avX6/d/LewsBCbNm1CcHAwmjRpordzk3HwcbNBdEEpElPzGaqIiIiISG/qFKq++OIL/PjjjxBFEQBgZWWF2NhYREREYOPGjXjhhRcwc+ZMnRR6v169eqFXr15YtGgR7ty5Az8/P2zYsAHJyclYsGCBXs5JxsXLzRbRsVlITDOcOVVEREREZHpqHap2796NFStWoGXLlnjrrbfQoUMH2NraorS0FGfPnsXChQvxww8/oG3bthg4cKAua9b6+uuv8eWXX2Lnzp0oKipCQEAAfvrpJ732kJHx8HEvX6wkMTVf4kqIiIiIyJQJoqabqYbCwsKQlJSEHTt2wMnJqdL9mZmZGDVqFJo1a4ZffvmlzoXWF5VKjcxM6Xs2FAoZnJxskJVVYFST9AxJXHIePlz1N2wsFVjyRq9aL7OvS2xX08M2NU1sV9PDNjVNbFfTY0ht6uxsU+3V/2q9PN/Vq1fRr1+/KgNVeRHO6NevHy5fvlzbUxDVSWNXa8gEAQXFSmTnl0pdDhERERGZKL1vVVxWVqbvUxBVyUwhh4dz+cZxiWkcAkhERERE+lHrUBUQEIDDhw8jOzu7yvszMzNx6NAhBAQE1PYURHXm7cZ5VURERESkX7UOVVOmTEFaWhqee+45nDlzBkqlEgCQn5+Po0eP4tlnn0VGRgYmT56ss2KJaspbs1gFe6qIiIiISE9qvfrf0KFDceHCBaxcuRLPPPMMZDIZzM3NUVxcDAAQRRFTp07F8OHDdVYsUU15u9kAABJSpV98hIiIiIhMU532qZo3bx4GDBiALVu24MqVKygoKICNjQ1atWqFsWPHcmlzkpzP3eF/dzIKoFSpoajmCi5ERERERNVVp1AFAB07dmR4IoPl4mAJS3M5iktVSM4s1M6xIiIiIiLSlVp9bX/r1i1kZWVVed+SJUtw7ty5OhVFpCuCIHCxCiIiIiLSqxqFqtLSUsycORPDhw/H0aNHK92flpaG5cuXY/LkyXj11VeRn8+LWJKeZl5VYhrnVRERERGR7lU7VKlUKjz//PPYs2cPPD09q9z018rKCm+99RaaNGmCgwcP4qWXXoIoijotmKimuAIgEREREelTtUPV+vXrcebMGYwcORL79u1Dnz59Kh1ja2uL559/Htu3b8eAAQNw7tw5bNq0SacFE9WUdvgfQxURERER6UG1Q9XOnTvRuHFjfPrpp1AoHr6+haWlJT777DM4OTlh27Ztda2RqE40w/8yc0tQUFwmcTVEREREZGqqHaquX7+Onj17wszMrFrH29raokePHrh69WqtiyPSBWtLM7jYWwAAkjivioiIiIh0rEZzquzs7Gr04B4eHlAqlTUuikjXvO4OAUzgCoBEREREpGPVDlWNGjVCfHx8jR48Pj4eHh4eNS6KSNd87i5WkcR5VURERESkY9UOVZ06dcKxY8eQlpZWrePT0tJw5MgRBAQE1Lo4Il3xujuvKoGhioiIiIh0rNqhKiwsDKWlpXj99dcfuf9Ufn4+XnvtNZSVlSEsLKzORRLVlY+bpqeqAGou809EREREOlTtUBUYGIiXXnoJERERGDx4ML799lucP38eeXl5UKvVyMrKQlRUFJYtW4ZBgwYhMjISY8eORffu3fVZP1G1eDhbQy4TUFyqQkZOsdTlEBEREZEJefja6Pd5/fXXYWZmhuXLl2PJkiVYsmRJpWNEUYSZmRmmT5+OmTNn6qxQorpQyGVo7GqDhNR8JKbmw83RSuqSiIiIiMhE1ChUCYKAV155BUOHDsXWrVtx/PhxpKSkIDc3F46OjvDx8UGvXr0wfPhw+Pj46KtmolrxdrsbqtLyEervJnU5RERERGQiahSqNHx9fTFz5kz2RJFR8Xa3BaJTkMC9qoiIiIhIh6o9p4rI2P27WAVXACQiIiIi3WGoogZDswFwcmYhSstUEldDRERERKaCoYoaDEdbc9hamUEUgTsZhVKXQ0REREQmgqGKGgxBEOCt2QQ4lUMAiYiIiEg3GKqoQfG+OwQwkfOqiIiIiEhHGKqoQfF2Z6giIiIiIt1iqKIGRdtTxeF/RERERKQjDFXUoHi52kAAkFtYhpyCUqnLISIiIiITwFBFDYqFuRxuTlYAOASQiIiIiHSDoYoaHM0QwCQOASQiIiIiHWCoogZHu6w6e6qIiIiISAcYqqjB8dGuAFggcSVEREREZAoYqqjB0Qz/u51eALValLgaIiIiIjJ2DFXU4Lg5WsHcTIYypRopWYVSl0NERERERo6hihocmUyAl2v5vCoOASQiIiKiumKoogaJmwATERERka4wVFGDpA1VXAGQiIiIiOqIoYoaJO+7KwAmsKeKiIiIiOqIoYoaJM1eVek5xSgqUUpcDREREREZM4YqapDsrM3hYGsOAEhK52IVRERERFR7DFXUYPlwXhURERER6QBDFTVYXAGQiIiIiHSBoYoaLG937lVFRERERHXHUEUN1r09VaIoSlwNERERERkrow9Vly9fxvPPP4/Q0FCEhITg2WefxYULF6Qui4xAIxcbyAQBhSVKZOWVSF0OERERERkpow5VsbGxeOqpp3DhwgW88MILeP311xETE4Onn34aV69elbo8MnBmChk8XawBcLEKIiIiIqo9ow5Vq1atQkFBAb777ju8/PLLmDZtGlavXg2lUonly5dLXR4ZAc1+VZxXRURERES1ZdShKiEhAdbW1ggNDdXe1rRpUzRt2pQ9VVQtXAGQiIiIiOrKqEOVr68vCgsLkZycrL2tuLgYqampcHd3l7AyMhbe7uWhKoHD/4iIiIiolow6VE2fPh1eXl6YOXMmoqOjcfPmTcydOxcFBQWYPn261OWREdAM/0vOKIRSpZa4GiIiIqKqcaViw6aQuoC68PT0xMsvv4wPP/wQY8eO1d7+4YcfolevXrV+XIVC+qwpl8sq/Jf0w8PZGlYWchSVqJCaXYQmHnZ6PR/b1fSwTU0T29X0sE1NU0NoV7VaxJo/r+Lc1VQ8PyIQwc1dpS5Jr4y1TY06VH399ddYvnw52rVrh0mTJkGhUGDr1q344IMPoFKp8NRTT9X4MWUyAU5ONnqotnbs7a2kLsHk+TV2wKWYTGQVlKFdPbU929X0sE1NE9vV9LBNTZOptqtaLeKbjZE4eC4RAPD1xvN477kuCPE3/WkuxtamgmikfYm5ubno0aMHfH19sXnzZpibm2vve/755xEeHo4DBw7A09OzRo+rUqmRm1uk63JrTC6Xwd7eCrm5RVBxWJperdpzBYfOJWJYt6aYMKClXs/FdjU9bFPTxHY1PWxT02TK7SqKIn7ZcwWH/kmCIAB+jexx63YuzBUyzA4LQWtfZ6lL1AtDalN7e6tq95gZbU9VbGwsSktLMXTo0AqBCgDGjh2L48eP459//sHQoUNr/NhKpeG8KVUqtUHVY4q8XMt7p+JT8uvtuWa7mh62qWliu5oetqlpMrV2FUURvx24Xh6oADw/LBAdW7lj2dYLOH8zA1/8HolZT4bA38dR6lL1xtja1LgGK97DwsICAKBSqSrdp+l8U6uNpyFIOv/uVcUVAImIiEhaoiji90M3tEP+nh3aCt2CPGGmkOHVMUFo4+eM0jI1vtwYhRtJORJXSxpGG6patmwJDw8PbNu2DQUF/27cqlarsWHDBigUCnTs2FHCCslYeLmWL6uelVeC/KIyiashIiKihkoURWw6ehP7/k4AAEwZHIBewY2195sp5HhtbFu0buqEklIVvtwQiZg7uVKVS/cw2lAlk8nw/vvv4/bt23jiiSfw888/Y/Xq1Zg0aRLCw8Px8ssv13g+FTVM1pYKuNhbAgCS2FtFREREEtl2PAZ7wuMBAE895o++IV6VjjE3k+P1J4Lh7+OIohIVvlgfibjkvPoule5jtKEKAAYMGIBffvkFnp6eWLp0KRYtWoTS0lIsXLgQM2bMkLo8MiI+dzcBTkwreMSRRERERLq342QMdv4VCwAIG9ASAzp4P/BYC3M53hwfjBbeDigsUeLz9RFISOUXw1Iy2oUqNDp16oRVq1ZJXQYZOS83G0TeSOcHEhEREdW73eFx2HY8BgAwvl9zDOrk88ifsTRXYOb4dvji90jcup2LResiMG9SKLzcbPVdLlXBqHuqiHTl354qhioiIiKqP3+eicemIzcBAGN7N8OQLk2r/bNWFgrMerIdmnraIb+oDIvWR+JOBkfdSIGhigjQfquTlFYAtXFu3UZERERG5sDZBPx+6AYAYGQPXwzv7lvjx7C2NMPsCSFo4m6L3IJSLFwXgZTMQh1XSo/CUEUEwNPZCgq5gJIyFdKzpd/8mYiIiEzb4Ygk/HbgOgBgWLemGNXTr9aPZWtlhtlhIfBys0FOfnmwSuX1TL1iqCICIJfJ0NhVs18Vu82JiIhIf45F3caaP68CAAZ3boKxvZtBEIQ6PaadtTnmhIWikYs1svJKsOi3f5Cew2BVXxiqiO7yvjsEMJGLVRAREZGenLxwB7/suQIAGNjRG+P7Na9zoNKwtzHHnImh8HC2RkZuCRb+FoHM3GKdPDY9HEMV0V3aUMXFKoiIiEgPwqOT8fPuyxAB9GvvhYkDWuosUGk42lpg7sRQuDtaIT2nGAvXRSArr0Sn56DKGKqI7vJ2Lx/+l8Dhf0RERKRjf19JxY9/XIYoAr3bNcZTj/nrPFBpONlZYM7EULg6WCI1qwiL1kUgp6BUL+eicgxVRHf53O2pSs0qREmZSuJqiIiIyFT8cy0NP+yIhloU0aOtJ6YMDoBMT4FKw8XBEnMnhsLZ3gLJmYVYtC4CuYUMVvrCUEV0l72NOWytzCCKwO109lYRERFR3UXeSMe32y5CpRbRrY0Hpg5prfdApeHqaIW5E0PhaGuO2+kF+HxdJPKLyurl3A0NQxXRXYIg/LsJMBerICIiojq6cCsDy7degEotonNrd0wb1hoyWf0EKg13J2vMndQeDjbmSEzLx+frI1BQzGClawxVRPfwcuOy6kRERFR30bGZWLr5ApQqER0C3PD88EDIZdJcens6W2POxFDYWZshPiUfi3+PRGGxUpJaTBVDFdE9fLgCIBEREdXRlbgsLN10HkqVGiEtXPHiyDZQyKW97G7saoM5E0Nha2WGmDt5+HJjJIpKGKx0haGK6B7ed4f/JaTmQxRFiashIiIiY3MtIRtfbzqPUqUawc1d8PLoIMkDlYa3my3eCguBjaUCN5Ny8dXGKJSUcnEuXTCMFiYyEI1dbSAAyC8qQy6XHiUiIqIauJmUgy83RqGkTIU2vk54dUwQzBSGdbndxMMOs8NCYGWhwPXEHHy9KYqrHuuAYbUykcQszORwd7YGwHlVREREVH0xd3KxeEMkSkpVaNXEETOeCIaZQi51WVXy9bTHrAntYGkux5X4bCzdfB5lSgarumCoIrqP993FKhK4AiARERFVQ1xyHr5YH4miEhX8vR3wxrh2sDAzzECl0byxA2Y+WV7npdgsLN1yAWVKtdRlGS2GKqL7aBarSOJiFURERPQICanly5QXlijRwssBb4xvBwtzww5UGi29HfHm+GCYK2S4eCsT3267CKWKwao2GKqI7uN1N1QlMFQRERHRQySlF9zd90kJv0b2eHN8O1hZKKQuq0YCmjjhjXHBMFPIEHkjHd9tj2awqgWGKqL7+LiXD/+7nV4IlZofKkRERFTZnYwCLFoXgbzCMjT1sMPsCe1gbWlcgUqjta8zXnuiLRRyAf9cS8OKnZd4DVRDDFVE93F1tIKFmRxKlRopmUVSl0NEREQGJiWrEIvWRSC3oBQ+7raYHRYCa0szqcuqkyA/F8wY2xZymYC/r6Tipz8uQ63m9jLVxVBFdB+ZIMDr7mIV3ASYiIiI7pWWXYSFv0UgO78UXq42mB0WAlsr4w5UGsHNXfHK6CDIZQLCL6Vg5e7LUHPfzmphqCKqgjdDFREREd0nPac8UGXllaCRizXemhgKe2tzqcvSqVB/N7w4sg1kgoCTF5Oxeu8VBqtqYKgiqoL33cUqElO5VxUREREBmbnFWLQuAhm5xfBwssKciaFwsDGtQKXRsZU7po8IhCAAx6LuYO2+axAZrB6KoYqoCtpQxZ4qIiKiBi8rrwSL1kUgLbsYbo6WmDMxFI62FlKXpVddAj3w/LBACAAORyRh3YHrDFYPwVBFVAVv9/JQlZ5TjKISpcTVEBERkVRyCkrx+foIpGQVwcW+PFA521tKXVa96BbkiWeHtgIAHDiXiA2HbzBYPQBDFVEVbK3M4GRX/g1UUhqHABIRETVEuYWl+HxdBO5kFMLJzgJzJ4XC1cFK6rLqVa/gxpgyOAAA8OeZBGw5dovBqgoMVUQPoFkBkJsAExERNTz5RWX4fF0kktIL4GhrjrmTQuHm2LAClUbfEC889Zg/AGDXqThsPxEjcUWGh6GK6AF8OK+KiIioQSooLsMX6yORmJYPextzzJkYCg8na6nLktSADt4IG9ASALDjZCx2/hUrbUEGhqGK6AH+XQGQoYqIiKihKCxWYvHvkYhLyYOdtRnmTAxFIxcbqcsyCIM6+WB8v+YAgK3HbmFPeJzEFRkOhiqiB9AsVpGYVsCxw0RERA1AUYkSX26MRMydPNhamWFOWCi8XBmo7jWkS1OM6d0MALDxyE3sOxMvcUWGgaGK6AEauVhDLhNQVKJEZm6J1OUQERGRHpWUqvD1xijcTMqFtYUCsyeEaL9gpYpGdPfFyB6+AID1h27g4LlEaQsyAAxVRA+gkMvg6VI+fpqLVRAREZmukjIVvt4UhWuJObCykGN2WAiaetpJXZZBG9XTD8O6NQUArN1/DUcikySuSFoMVUQPoZlXlcRQRUREZJLKlCp8s/k8rsRnw9JcjllPhsCvkb3UZRk8QRAwtnczDO7cBACweu9VHI+6LXFV0mGoInoIb82y6lysgoiIyOSUKdX4ZstFRMdmwcJMjjfHt0NzLwepyzIagiBgfL/mGNjRGwCwas8V/HXxjsRVSYOhiughfNw1PVXcAJiIiMiUKFVqfLvtIi7cyoC5QoY3xwfD38dR6rKMjiAImDigJfqFekEE8NOuyzh9KUXqsuodQxXRQ2iG/93JKESZUi1xNURERKQLSpUa32+PRuSNdJgpZHh9XDACmjhJXZbREgQBTw3yR+92jSCKwIqdl3D2SqrUZdUrhiqih3Cys4C1hQJqUcSdDPZWERERGTuVWo0f/7iEc9fSoJALeG1sWwT6OktdltGTCQKmDG6FHm09oRZFfL8jGhHX0qQuq94wVBE9hCAI2nlViVysgoiIyKip1SJ+2nUZZy6nQi4T8MqYtghq5iJ1WSZDJgiYOqQ1urbxgEotYvm2i4i6kS51WfWCoYroEe7dBJiIiIiMk1oUsXLPZYRHp0AuE/Dy6CCEtHCVuiyTI5MJeG5Ya3Rq5Q6VWsSyrRdw8VaG1GXpHUMV0SNo5lUlcgVAIiIio6QWRazeexUnLyRDJgh4cWQbtPd3k7oskyWXyTB9RCA6+LtBqRKxdMsFXIrNlLosvWKoInqEf3uqGKqIiIiMjSiKWLv/Go5F3YYgAM+PaI2OrdylLsvkKeQyvDiqDUJauKJMqcaSTedxNT5L6rL0hqGK6BG8XMvnVGXnlyKvsFTiaoiIiKi6RFHEuoPXcfifJAgApg1tja6BnlKX1WAo5DK8PDoIbZu5oFSpxlcbz+N6YrbUZekFQxXRI1hZKODqYAmA86qIiIiMhSiK2Hj4Jg6cTQQAPDukFXq0bSRxVQ2PmUKGGWOD0MbXCSVlKny5IQo3b+dIXZbOMVQRVYN2XhWHABIRERk8URSx5dgt7D0TDwCY8ngAerVrLHFVDZeZQo4ZTwSjVRNHFJeqsPj3KMTcyZW6LJ1iqCKqBu28Ki5WQUREZPB2nIzFrlNxAICnHvNH31AviSsiCzM53hjXDv7eDigqUWLx75GIT8mTuiydMfpQVVxcjC+//BL9+/dHu3btMGLECGzdulXqssjE+HBZdSIiIqPwx1+x2H4iBgAQ1r8FBnTwlrgi0rAwl+ON8e3Q3MseBcVKfL4+0mS+sDbqUKVWq/HKK69gxYoV6N+/P+bNmwcnJye8/fbbWL9+vdTlkQnRbACclJ4PtShKXA0RERFVZc/pOGw5dgsAML5vcwzq3ETiiuh+VhYKzBwfAr9GdsgvKsOi9RFISjf+L62NOlRt27YNJ0+exH//+1+8++67mDRpElatWoXAwEB88803EHnxSzri7mQFM4UMpWVqpGUXSV0OERER3Wff3wnYePgmAGBMLz8M6dpU4oroQawtFZg1IQRNPeyQV1iGz9dF4E6GcQcrow5VmzdvRpMmTTBx4kTtbTKZDG+++SbCwsJQWFgoYXVkSuQyGRq7lPdWmUo3NRERkak4cDYB6w9eBwCM7OGLET38JK6IHsXG0gyzw0Lg7WaLnIJSLFoXgZQs4712N9pQVVZWhqioKHTr1g0yWfmvUVBQAFEU0adPH8yYMQM2NjYSV0mmxNv9bqjivCoiIiKDsfdULFbvvQoAGNq1KUb1ZKAyFrZWZnhrYgi8XG2QnV8erNKyjHNEkNGGqsTERJSVlcHLywurVq1C79690b59e3Tt2hXffvsth/6RzmmXVWdPFRERGTBRFKFSqxvE/45F3sayTVEAgMc7++CJPs0gCILELUA1YW9tjrcmhqKRizUyc0vwv1/PIdUIe6wUUhdQW3l55UswbtmyBTk5OXj55Zfh7u6O7du346uvvkJRURFmzZpVq8dWKKTPmnK5rMJ/SXpNPe0AlO9VVdvXCNvV9LBNTRPb1fQ0lDa9nV6ArzdG4U6G8V2U1sXjnZtg0mMtGaiMlIuDJd6e3AHz15xDSmYhPv7pND6Z3sUgrsmry2hDVWlpKQAgISEBW7ZsQatWrQAAQ4YMwdNPP42ff/4ZU6ZMgaura40eVyYT4ORkOMMG7e2tpC6B7grylwMAUrOLYGVtAUuL2r992K6mh21qmtiupseU2/R2Wj4W/vYPMnNLpC6l3sgEYHivZnh+ZBADlZFzcrLBgld74oMVpyCTCbCzs4JMZjxtarShysqq/EMxODhYG6g0xo4dizNnzuDcuXN4/PHHa/S4arWI3Fzpv92Ry2Wwt7dCbm4RVCq11OXQXfY25sgtKMXF66lo7uVQ459nu5oetqlpYruaHlNv09SsQsxffQ6ZeSXwdrPBrAkhsKrDl3/GwtxcDndXO5Nt14ZGDuCTF7rC3s4K+fnFkrepvb1VtXu3jfbd5unpCQBwdnaudJ/mtoKC2i0ooFQazptSpVIbVD0NnZerDXILShGXnIemHna1fhy2q+lhm5omtqvpMcU2Tc8pwmdr/0FmXgkauVjjrbBQ2NuYS11WvVDcveA1xXZtqBQKGWQyweja1HgGKt7HxcUFnp6euHnzZqX7EhMTAQCNGjWq77LIxPm4c7EKIiIyHJm5xVj4WwQyckvg4WyNORMbTqAiMiRGG6oAYMSIEYiNjcW+ffu0t5WWluK3336Ds7MzOnbsKGF1ZIq0KwCmMVQREZG0svJKsHBdBNJziuHuaIW5E0PhaGshdVlEDZLRDv8DgJdeegkHDx7EW2+9haeeegpeXl7Ytm0bbt68iS+++AJmZmZSl0gm5t69qkRR5KRYIiKSRE5+CRati0BqVhFcHSwxZ2IonOwYqIikYtShytbWFr/99hu+/vpr7NixA3l5efD398e3336Lfv36SV0emaDGLjYQBCC/qAw5BaX8RpCIiOpdbmEpFq2PRHJmIZztLTB3YihcHCylLouoQTPqUAUATk5O+OCDD/DBBx9IXQo1AOZmcng4WSM5sxCJqfkMVUREVK/yi8rw+bpI3E4vgKOtOeZODIWro+kuE09kLIx6ThWRFLw1i1Wk1W51SSIiotooKC7D5+sjkJiWDwcbc8yd1B7uTtZSl0VEYKgiqjFvt/J5VQlcAZCIiOpJYbESi3+PRHxKPuyszTBnYig8nRmoiAwFQxVRDflwBUAiIqpHRSVKfLkhEjF38mBrVR6oGrvaSF0WEd2DoYqohrzuDv+7k1EAJXdvJyIiPSouVeKrjVG4eTsXNpYKvBUWot3eg4gMB0MVUQ25OljCwlwOpUpESmah1OUQEZGJKilTYcmm87iemAMrCwVmh4WgiYed1GURURUYqohqSCYI8Hb9d78qIiIiXSstU2Hp5vO4Ep8NS3M5Zk1oB19Pe6nLIqIHYKgiqoV/VwDkvCoiItKtMqUa32y9gEuxWbAwk2Pmk+3QvLGD1GUR0UMwVBHVgmY8eyJXACQiIh1SqtRYvvUCLt7KhLlChjfHB6Olt6PUZRHRIzBUEdWCZll19lQREZGuKFVqfLc9GlE3M2CmkOGNccEIaOIkdVlEVA0MVUS1oBn+l5FbgsJipcTVEBGRsVOp1fhh5yX8cy0NCrmA155oi9a+zlKXRUTVxFBFVAs2lmZwsrMAwN4qIiKqG7VaxE9/XMbZK6mQywTMGNsWQX4uUpdFRDXAUEVUSz53e6uSGKqIiKiW1KKIlbsvI/xSCuQyAa+MDkJwc1epyyKiGmKoIqolr7vzqhK4rDoREdWCWhSxeu8VnLyYDJkg4MWRbRDq7yZ1WURUCwxVRLXkwxUAiYiolkRRxNp913As6g4EAZg+IhAdW7lLXRYR1RJDFVEtaZdVT8uHKIoSV0NERMZCFEWsO3AdhyOSIAB4flggugR6SF0WEdUBQxVRLXm6WEMuE1BcqkJGTrHU5RARkREQRREbDt/AgXOJAIBnh7ZCtyBPiasiorpiqCKqJYVchkYu1gCARM6rIiKiRxBFEZuP3sKfZxIAAFMGB6BXcGOJqyIiXWCoIqoDzX5VCVwBkIiIHmH7iRjsDo8DADz1mD/6hnhJXBER6QpDFVEdaBar4LLqRET0MDtPxmDHyVgAQNiAlhjQwVvagohIpxiqiOrA626oSuAKgERE9AB7wuOw9XgMAGB8v+YY1MlH4oqISNcYqojqQLMBcEpmEcqUKomrMSxcEZGICNh3Jh4bj9wEAIzp3QxDujSVuCIi0geGKqI6cLQ1h42lAmpRxO30QqnLMRinL6Vg5jcnsfnoTYYrImqwDp5LxPpDNwAAI3v4YkR3X2kLIiK9YagiqgNBECrsV0XA31dSsWLnJeQWlGLXqThsPMJgRUQNz5GIJKzdfw0AMKxbU4zq6SdxRUSkTwxVRHXEUPWvf66l4Ycd0VCLIpo3tgcA7D0dj63HbzFYEVGDcTzqNlb/eRUAMLhzE4zt3QyCIEhcFRHpE0MVUR15u9sAABIb+GIVkTfS8e22i1CpRXRt44H/TO6AiQNbAgD++CsOO++uekVEZMr+ungHq/ZcAQAM7OiN8f2aM1ARNQAMVUR19G9PVcPdAPjCrQws33oBKrWIzq3d8dyw1pDJBDzW0QdP9msBANh2Iga7TsVKWygRkR6FX0rGT7suQwTQr70XJg5oyUBF1EAwVBHVkZdbeU9VTkEpcgtLJa6m/kXHZmLp5gtQqkR08HfD88MDIZf9+9EyuEsTPNGnGQBg89Fb2Hs6XqpSiYj05uyVVPy48zJEEejdrjGeesyfgYqoAWGoIqojS3MF3B2tAABJDWwI4JW4LCzddB5KlRohLVzx4qg2UMgrf6wM6+aL0XcnaW84fAP7/06o71KJiPQm4loavr87n7RHW09MGRwAGQMVUYPCUEWkA5reqoQGNATwWkI2vt50HqVKNdo2c8HLo4OqDFQaI3v6Yfjd5YTXHbyOQ/8k1lOlRET6E3UjHcvvmU86dUhrBiqiBoihikgHNJsAN5QVAG8m5eCrjVEoKVOhja8TZowNgpni0R8nY3r5YUiXJgCAX/ddw9HIJH2XSkSkNxdvZWBZFfNJiajhYagi0gHtYhUNYPhfzJ1cLN4QieJSFVo1ccSMJ4JhppBX62cFQcC4vs0xqJMPAGD13qs4cf6OPsslItKLS7GZWLrlwfNJiahh4bufSAe87/ZU3U4vgFptuvsxxSXn4Yv1kSgqUcHf2wFvjGsHC7PqBSoNQRAwoX8LDGjvDRHAyt2XcSo6WT8FExHpwdX4LCzZdB5lyofPJyWihoOfAEQ64O5oBXOFDKVKNVKzi6QuRy8SU/Pxxe+RKCxRormXPd4Y3w4W5jULVBqCIGDSYy3RN6QxRAA//nEJZy6n6LZgIiI9uJ6Yja82Vn8+KRE1DPwUINIBmUxAY1fT3QQ4Kb0Ai9ZHIL+oDH6N7DFzfAisLBR1ekxBEDD58QD0DG4EUQR+2HEJ566m6qhiIiLdu5mUgy831Hw+KRGZPn4SEOnIv5sAm1aoupNRgEXrIpBXWIamHnaYNaEdrC3rFqg0ZIKAZwe3Qrc2nlCLIr7bHo3I6+k6eWwiIl0qn08aVav5pERk+hiqiHREM68qwYR6qlKyCrFoXQRyC0rh426L2WEhsLE00+k5ZDIBzw1rjc6t3aFSi1i+7QLO38zQ6TmIiOoiLjkPi3+PRFGJstbzSYnItDFUEemI9929qpJMZK+qtOwiLFoXgez8Uni52mB2WAhsrXQbqDRkMgHTRwSiY4AblCoR32y5gOiYTL2ci4ioJjTzSQuK6z6flIhMF0MVkY5oeqpSs4tQXKqUuJq6ycgpxsLfIpCZW4JGLtZ4a2Io7K3N9XpOuUyGF0a2QWhLVyhVaizZfB6X47L0ek4ioofRx3xSIjJNDFVEOmJvbQ4Hm/LgkZRuvL1VmbnFWLjuH2TkFsPDyQpzJoZqfy99U8hleGlUEIKbu6BMqcbXm6JwLSG7Xs5NRHQvfc4nJSLTw1BFpEOaIYDGugJgdn4JFq2LQFp2MdwcLTFnYigcbS3qtQYzhQyvjglCkJ8zSsvU+HJjFG4k5tRrDUTUsNXHfFIiMi0MVUQ6pBkCmGiE86pyCkqxaF0EUrKK4GJfHqic7S0lqcVMIceMsW3RuqkTSkpV+HJjJG7dzpWkFiJqWOpzPikRmQ6GKiId0i6rbmQ9VbmFpfh8XQTuZBTCyc4CcyeFwtXBStKazM3keH1cMAJ8HFFUosLi3yMRl5wnaU1EZNoycoqxaF39ziclItPAUEWkQ/fuVSWKosTVVE9+URm+WB+JpPQCONqaY+6kULg5ShuoNCzM5HhjfDBaeDugsESJz9dHID6FwYqIdC8rrwQL1/2D9Jz6n09KRMaPoYpIhxq7WkMmCCgoViI7v1Tqch6psLg8UCWk5sPexhxzJobCw8la6rIqsDRXYOb4dmjW2B4FxUp8vj7S5DZYJiJpZeeXYOFv/0g6n5SIjBtDFZEOmSnk8HAu7+Ux9E2AC4uV+OL3KMSl5MHO2gxzJoaikYuN1GVVycpCgVlPtoOvpx3yi8ruDlU0vnlrRGR4DGk+KREZL5MJVUlJSWjfvj3efvttqUuhBk4zBDDJgHtTikqU+GpjFGLu5MLWygxzwkLh5WqYgUrD2tIMsyaEoIm7LXILy7BwXQRSMgulLouIjFheYSk+X//vfNI5BjCflIiMk0mEKlEU8c4776CggN9ck/Q0KwAmGGioKilV4euNUbiRlANrCwVmTwjR1mzobK3MMDssBN5uNsjJL8XCdRFIzWKwIqKayy8qw+frI5GUVgCHu/NJ3Q1kPikRGR+TCFVr167FuXPnpC6DCMC9e1UZXsgvKVOVb6ibmAMrCzlmh4Wgqaed1GXViJ21Od4KC0UjF2tk5ZXvq5WeXSR1WURkRAqLy/DF7//OJ51rgPNJici4GH2oio+PxxdffIEZM2ZIXQoRAMDn7vC/OxkFUKrUElfzrzKlCt9sPo8r8dmwNJdj1pMh8GtkL3VZtaJdVMPZGhm5JVi4LgKZucVSl0VERqCo5O580mTDn09KRMbDqEOVWq3G22+/jYCAADzzzDNSl0MEAHBxsISluRwqtYhkA5nzU6ZUY9nWi4iOzYKFmRxvjm+H5l4OUpdVJ462Fpg7sXy4TnpOMRaui0BWXonUZRGRASssLl/oJuZOLmwsFXjLCOaTEpFxMOpQ9csvv+DixYuYP38+ZDKj/lXIhAiCYFCbACtVany77SLO38yAuUKGN8cHw9/HUeqydMLJzgJzJobC1cESqVlFWLQuAjn5DFb6IooiVGp1g/kfmZaSUhU++uk0rieWzyd9KywUPkYyn5SIDJ9C6gJq69atW/jqq6/wxhtvoFmzZigp0d2FlEIhfUCTy2UV/kvGpYmHLW4k5eB2RmGF11N9t6tSpcYPO6MReSMdZgoZZk4IQRs/53o5d33xcLHGf57ugE9Xn0VyZiE+Xx+J/zzdAfb1tGlnQ3ivqtUiTl1MxvYTMQbT+1of2jRzwaiefmjVxFHqUqgORFFE1I0MbDpyA/Ep+bCyUGDuU6Fo1ti4e+upXEP4DG5ojLVNjTJUqVQq/Oc//0Hr1q0xdepUnT62TCbAyclwhgLY23MlImPk7+uCQ/8kITmrqMrXU320q0qlxhe//YOzV9KgkMvw7tQuaN/KXe/nlYKTkw0WvNoL/1l+AknpBfh8fSQ+fblHvQUrwDTfq2q1iBNRSfjtz6sGvUWAvkTfykD0rQwEt3DFU4NbIdDPReqSqAZEUUTktTSs3XsFV+OzAAA2lgp88EI3tGpqWl8ukWl+Bjd0xtamRhmqfv75Z1y8eBGrV69GdnY2AKCsrAwAUFpaiszMTNja2sLcvOYXVGq1iNxc6b+JlctlsLe3Qm5uEVQGtNgBVY+Lbflr71ZSNrKy/l0FsL7aVa0W8cOOaPx1MRlymYDXxrWFn4dNhVpMjaUcmDspFPPXnEPsnVy8s/wE3n6qPWyszPR6XlN8r4qiiLNX07D16E0kppW/ZmyszDC0a1P0btcICiP79rA2istUOHAuCXtPxeL8jXSc/+YE2jZzwdg+zYx+PmJDcDk2E1uO3sLVhGwAgLlChsc6N8HEx1tBUKtN+rOwoTHFz+CGzpDa1N7eqto9ZoIoiqKe69G5p59+GmfOnHnoMf/73/8wduzYGj+2SqVGZqb0H7YKhQxOTuUXwUolPySMTWFxGWZ8dRwAsPTNXrCxLL+wr492VYsiVu6+jJMXygPVy6OD0N7fTS/nMkS30wuw8Ld/kFtYBl9PO7wVFgprS/19f2RK71VRFBF1MwPbjt9CfEp5z5SVhQKPd/LBY518YGVhlN/D1YqmXa/HZmDbsVs4eeEOVOryP5ftmrtgdK9mRrcdQUNwIzEHW4/fwuW48p4phVyGfqFeGNq1CVwcrUzmvUr/MqXPYCpnSG3q7GxT7VBllH8h582bh9zc3Aq3lZWV4YUXXkDPnj3x3HPPoUWLFhJVRwRYW5rBxd4CGbklSEzNR0ATp3o5r1oUsXrvVZy8kAyZIODFkW0aVKACgMauNnhrYigW/haB2OQ8fLkhErMmhDSoQFBToigiOjYT247H4Nbt8s9WC3M5Huvog8c7+2i/FGiIXB0s8eyQVhjarSl2nozBXxeTEXUzA1E3M9DB3w2jevlpF6Yh6dy6nYttJ27h4q1MAIBcJqB3SGMM7+YLJzsLiasjoobAKK8ygoKCKt2mWajCzc0N3bt3r++SiCrxcrMtD1VpBfUSqkRRxNr913As6jYEAXh+RGt0NNE5VI/i7WaLt8JCsGhdBG7ezsVXG6Mw88l2sDQ3yo88vbocl4Vtx2/hemIOAMDcTIYB7b0xuEsT2FnX35w0Q+fuaIXnhgViWDdf7DgRg9OXUnDuWhr+uZaGTq3dMaqnH/c6kkB8Sh62HY9B5I10AIBMENAz2BPDu/vC1cG45mMQkXHjFQaRnvi42+L8zQwk1sMEf1EUse7gdRz+JwkCgGlDW6NroKfez2vImnjYYXZYCBati8T1xBws2XQeb4xvBwszudSlGYTridnYeuwWrsRnAygfJtW/vReGdG0Kh3pc4MPYeDpb44WRbTCsW1NsPxGDs1fTcOZyKv6+koqugZ4Y2dMXHk7WUpdp8hLT8rH9eAzOXUsDAAgC0L2NJ0b08IU7n38ikgBDFZGeeLmVf2ut71AliiI2HrmJA2cTAQDPDmmFHm0b6fWcxsLX0x6zJrTDF+sjcSU+G0s3n8frTwTDvAEHq1u3c7Ht+C1cjPl3mFSfkMYYxmFSNeLlZotXxrRFfEoetp+IQcT1dJyKTsbpSyno0bb84p49Jbp3J6MA20/E4O/LqRABCAA6B3pgZA9f9hQSkaRMJlRZWFjg6tWrUpdBpOWj2QA4rQBqUYRMEHR+DlEUseXYLew9HQ8AmPJ4AHq1a6zz8xiz5o0dMOvJEHzxeyQuxWbhm60X8NrYtjBTNKxgFZech23HbyHqZgaA8jDVo20jjOjuCxcHS4mrM15NPOzw2hPBiLmTi23HY3DhVgaOn7+Dvy4mo1e7xhjerSmc7fn81lVqViF2nIzFqehkaJbX6hDghlE9OaeNiAyDyYQqIkPj4WwNhVxASakKGTnFcHPU/bfWO0/GYtepOADAU4/5o2+ol87PYQpaeDvgzfHB+HJjFC7eysTyrRfx6ti2DWJp8CqHSQV5YkQPP7jr4TXZUPk1ssfMJ9vhRlIOth2/hUuxWTgSkYQT5++gb0hjDOvWFA627AmsqfScIuw8GYuTF5KhvpumQlq4YnQvPzTx4OqLRGQ4GKqI9EQhl6GRiw0SUvORmJqv81C161Qstp2IAQCE9W+BAR28dfr4piagiRPeeCIYX206j6ibGfhuezReGtXGZINVVcOkugR6YGRPP3g6c86JvrTwcsBbYaG4Gp+FrcdjcC0hGwfOJeJY1G30b++NwV2bwJ4LgDxSVl4J/vgrFseibmuXsg9q5owxvZrBr5G9xNUREVXGUEWkR95utuWhKi0foTpc2nzv6XhsPnoLADCub3MM6txEZ49tylr7OuO1J9piyaYL+OdaGn7YeQkvjgyEXGY6wSolqxA7TsQi/NK/w6Q63h0m5cVhUvUmoIkT5k1yxKW4LGw7dgs3b+di75l4HI5IwsCO3ni8cxPY6nljamOUk1+CXeFxOBJxG8q7m362buqEMb2aoYU3N10mIsPFUEWkR97uNkA0kJCmuw2l9/+dgA2HbwAAxvTyw9CuTXX22A1BkJ8LZowNwtLNF3D2SioUMgHPDw+ETKb7OW/1qaphUqEtXTGqJ4dJSUUQBLTxdUZgUydcuJWJrcdvIS45D7tOxeHQP4l4rKMPBnVqotfNqY1FbmEp9obH49A/iSi9u9mnv7cDxvRuVm/7/BER1QU/yYn0SLNYRZKOVgA89E8i1h28DgAY0d0XI3r46eRxG5rg5q54ZUwQlm+9iPBLKZDJBEwb1lovi4noW2ZuMf44FYfj9wyTatvMBaN7+XGYlIEQBAHBzV3QtpkzIq+nY+vxGCSm5WPHyVgcOJuIx7s0wcAO3g1yg+r8ojL8eSYeB84moqRMBQBo1tgeY3o1Q6CvEwQjfE8SUcPU8D7BieqRZrhVcmYhSstUUChqP8zsaGQSft13DQAwtGtTjO7FQFUXoS3d8OLINvhuezT+upgMuUzAM0NaGU2wyskvwa5TcTgS+e8wqUBfJ4zu1QwtvDhMyhAJgoBQfze0a+mKc1fTsO34LdzJKMTWY7ew/+8EDOnaBP3bezeIvdQKi5XY93c89p9NQFFJeZhq6mGH0b38ENzchWGKiIwOQxWRHjnamsPWygz5RWW4nVGAFt6OtXqcE+fvYPXe8i0DBnXywRN9mvGiQwc6tnLHC6KI73dE4/j5O5DLZXh6kL9BP7dVDpPyccSYXn4cJmUkZIKATq3c0cHfDWcup2D7iRikZBVh4+Gb+PNMAoZ1bYq+oY1Nctn/4lIlDpxNxJ9n4lFQrAQAeLvZYHSvZght6WrQ7z0ioodhqCLSI0EQ4O1mgyvx2UhMrV2oOhWdjJW7L0MEMKCDNyb0b8ELDx3q3NoDKpWIH/+4hCMRSZDLBEwa2NLgnuOqhkk1b2yP0b2bIbAph0kZI5lMQNc2nujU2h2nLqZgx8kYpOcUY93B69hzOg7Du/uiV3BjmNWhh9tQlJSpcPifJOwOj0N+URkAoJGLNUb19EPHVu5G00NMRPQgDFVEeubtZlseqmoxr+rM5RT8+McliAD6hnoZ5MW+KegW5AmlWo2Vu6/g4LlEyGWCwYTXKodJedphTK9maNvM2SBqpLqRy2ToGdwIXdt44MSFO/jjr1hk5pbg133XsCc8DiN6+KF7kKdRLv9fplThSMRt7AqPQ25BKQDA3ckKo3r6oUtrD6NfIIaISIOhikjPvN3L51XVNFSdu5qKH3ZcgigCvYIbYbKBD0szdr2CG0OlFrF671Xs+zsBCrlM0mGWRSVKHDiXiD9Px6OwRDNMyhZjevkhhMOkTJJCLkPfEC/0CGqEY1G38cepWGTklmDVnivYdSoWI3v4oWsbD6PYAkCpUuN41G38cSoOWXklAABXB0uM6OGL7kGeRvE7EBHVBEMVkZ55312sIjG1+qEq8no6vtseDbUoonuQp1EtoGDM+oZ4QaUSsXb/NewOj4NCLmB0r2b1WkNJmQqH/knEnvD4CsOkRvdqhg4BbnwdNABmChkGdPBGr+BGOBJRPmQuLbsYP+26jF2n4jCypy86t/YwyNeCUqXGXxeTsfNkDDJyy8OUk50FRnT3Rc/gRkbZ20ZEVB0MVUR65uVqAwFAbmEZcvJL4ORk89Djz9/MwPJtF6BSi+ga6IFpQ41zqW9jNaCDN1RqEesPXseOk7GQy4R6Wbq+qmFSHneHSXXmMKkGydxMjkGdm6BPiFd50D4dj+TMQvyw4xJ2/RWHUT390N5AgrZaLeJUdDJ2noxFanYRAMDB1hzDu/midzvTmBdGRPQwDFVEemZhLoebkxVSs4qQkJoPXx/nBx4bHZOJb7ZcgFIlomMrdzw3vDUvpiUwqJMPVGo1Nh6+ia3HYyCXy/S2yXKZUo3j52/jj79ikZ1fHqZcHSwxsocfugUZx1Av0i8LczmGdG2KvqFeOHA2AX+eSUBSegGWb7uIJu62GNXLDyEtpBkSqhZF/H05FdtPxCA5sxAAYGdthqFdm6JfqBfMG8Dy8EREAEMVUb3wcbNFalbRQ+dVXY7LwpLN56FUqdHe3w0vjAjkBbWEhnRpCpVKxJZjt7DpyE0oZAIGdW6is8evapiUs70Fhnf3Rc+2HCZFlVlZKDCihx8GdPDGn2cSsP9sAuJT87F08wX4NbLD6F7NEORXP4uXqEUR/1xNw/YTMUhKLwAA2FgqMKRrU/Rv7wVLc15eEFHDwk89onrg5WaDc9fSkJBSdai6lpCNrzdFoUypRrvmLnhpVBteVBuA4d19oVKL2H4iBusP3YBcXj7XpS5UajXCo8uXz07LLgbAYVJUM9aWZhjTuxke6+SDvafjceBcAmLu5OHLDVFo4eWAMb380Nr3wT3idSGKIqJuZGDb8VuIvztP1MpCgcc7++Cxjj6wsuBlBRE1TPz0I6oHPndXAEyoYrGKG4k5+HJjFErL1Ahq5oxXxrRloDIgI3v4QqlSY9epOKzdfw1ymYC+oV41fhy1KOLM5RTsOBGrHSZlf3eYVF8Ok6JasLUyw7i+zTGokw92h8fhcEQSbiTlYNH6SLRq4ojRvZrB38dRJ+cSRRHRMZnYejwGMXdyAZQPS3ysow8e7+wDG0sznZyHiMhYMVQR1QPNCoBJ6QVQqdTa22/dzsWXGyNRUqpCoK8TZoxpy54KAyMIAsb2bgaVWsTe0/FY/edVyGUCerVrXK2fr2qYlK2VGYZ0aYL+7b1hYc4wRXVjb2OOsAEt8XjnJth9Kg5Ho5JwJT4bC9b+gza+ThjduxmaN3ao9eNfjs3E1hMxuJGYAwAwNyvvsR3cuQnsrM119WsQERk1hiqieuDmaAVzMxlKy9S4nV4AW3MZ4pLzsPj3SBSVqNCqiSNeeyKYvRUGShAEjO/bHEqVGgfOJmLVniuQyQT0aNvogT8jiiIib6Rj+/EY7TAp67vDpAZymBTpgZOdBZ4a5I8hXZvgj79icfz8HUTHZiE69hyCm7tgTK9maOppV+3Hu5aQjW3Hb+FKfDaA8qXe+4V6YUjXpnCwYZgiIroX/6oT1QOZTICXqw1i7uQhLjkXdhZyfL4+AoUlSrT0dsDr44JhwUBl0ARBwMQBLaFSizj8TxJ+3n0ZcrmAnsEVe6xEUcTFmExsO34LMXfyAACW9wyTsuYwKdIzZ3tLTBncCkO6NsXOk7H462Iyzt/MwPmbGQht6YrRvZpphyRX5ebtHGw7HoPomEwAgEIuoHe7xhjWzRdOdhb19WsQERkVhiqieuLtZouYO3k4EXkb52+koaBYieaN7fHm+HZcKctICIKApx7zh0ol4ljUbfy48zLMFXI83qN8g+DLseVzTm4k/TtMamAHHwzu0gS2VgxTVL/cHK0wbVhrDOvWFDtOxiA8OgUR19MRcT0dnVq5Y1RPPzR2/XffvLjkPGw9fgvnb2YAAOQyAT2DG2F4N1+4OFhK9WsQERkFXskR1RPvu98Mnzx/GwDg62mHmU+GcBiYkZEJAqYMDoBKrcbJC8n4dttFFJSqEX7hNi7HZQH4d5jU0K5NYc9hUiQxD2drTB/RBsO6+WL7iRj8fSUVf19Jxdmrqega6IFubTxxJPI2/rmWBgAQBKB7kCdG9PCDu6OVxNUTERkHXs0R1RPNYhUA0NTTDrPDQmBtybegMZIJAqYOaQ21WsSp6BSs/CMaQPkwqT7tvDC0W1MOkyKD09jVBi+PDsLw1HxsO34LEdfTcSo6BaeiUwAAAoAubTwwsocfPJ2tpS2WiMjI8IqOqJ40a2QPVwdLODtY4o1xwbDikD+jJpMJmDasNWQyGU5fSkGvdo0wrGtTONtzmBQZNh93W7z2RDBik3Ox7XgMLtzKQIeA8uGAXvcMByQiouoTRFEUpS7CkKhUamRmFkhdBhQKGZycbJCVVQClUv3oHyCjIJMJcHa2QXZ2IdvVRCgUMtjbWyE3t4htakIa0mewUqVuEHvjNaQ2bUjYrqbHkNrU2dkG8mp+Ppr+pyiRAZHJBAiCIHUZpGPV/cAlMkQNIVAREekbP0mJiIiIiIjqgKGKiIiIiIioDhiqiIiIiIiI6oChioiIiIiIqA4YqoiIiIiIiOqAoYqIiIiIiKgOGKqIiIiIiIjqgKGKiIiIiIioDhiqiIiIiIiI6oChioiIiIiIqA4YqoiIiIiIiOqAoYqIiIiIiKgOGKqIiIiIiIjqgKGKiIiIiIioDhiqiIiIiIiI6oChioiIiIiIqA4YqoiIiIiIiOpAEEVRlLoIQyKKItRqw3hK5HIZVCq11GWQjrFdTQ/b1DSxXU0P29Q0sV1Nj6G0qUwmQBCEah3LUEVERERERFQHHP5HRERERERUBwxVREREREREdcBQRUREREREVAcMVURERERERHXAUEVERERERFQHDFVERERERER1wFBFRERERERUBwxVREREREREdcBQRUREREREVAcMVURERERERHXAUEVERERERFQHDFVERERERER1wFBFRERERERUBwxVREREREREdcBQRSQBURSlLoF0SKVSSV0C6Qnfq6aHbUpkHNRqtdQl1AhDlYG6/0OffwSMX1paGmJiYpCXlwdBEKQuh3TgwIEDAAC5XG50H/70YCkpKUhISEB+fj7fqyaipKQERUVFUCqVEASBf1NNwP1tyM9g03DvtZJMZlwxRRD5yWJwli9fjuvXr6OoqAh+fn6YNGkSfHx8pC6L6uDDDz/E6dOnkZCQADc3N0yYMAFDhgxBkyZNpC6Naumzzz7DypUr8Z///AfPPPMMgPI/6sb2R4Aq+uCDD3D69GkkJyfD0dER8+fPR8eOHWFmZiZ1aVRLixcvRnR0NLKysuDt7Y233noLTZo04fvViPE6yTQZ+7USQ5WBefHFFxEZGYmmTZuitLQUcXFxMDc3x+uvv46BAwfCw8ND6hKphl544QWcP38e/fr1g4eHBy5cuICTJ09i8uTJeP3112Fvby91iVQLv//+O95//31YWFhgxowZmD59OgAGK2M2Y8YMREZGYsCAAbCzs0NiYiJ69+6N0aNHQxAE9loZoRdeeAERERFo1aoVysrKcP78ebi4uGDDhg1o1KiR1OVRLfA6yTSZxLWSSAZjw4YNYo8ePcTdu3eLJSUloiiK4l9//SW+8MILYmBgoPjxxx+LcXFxEldJNfHTTz+JXbp0EXfu3CmWlpaKoiiKhYWF4qxZs8SQkBAxMjJS4gqptg4cOCAGBASI/fr1E9u3by+uWLFCe59KpZKwMqqNkydPij169BDXr1+vfa+WlZVJXBXVxU8//SR26tRJ/OOPP7RtumHDBjEwMFD873//K6pUKlGtVotqtVriSqm6eJ1kmkzlWolfpxqQ+Ph4AECHDh1gbm4OAOjWrRv+97//YezYsfj111/x448/IjExUcoyqQauXr0KBwcHdO/eHWZmZhBFEVZWVhgwYACKioqwefNmABwLbow6deqEFi1aYODAgfD29sZXX32Fn376CQDYU2WEbt++jczMTHTp0kU71E+hUGD16tX45JNPMHfuXBw+fBh37tyRuFKqrhs3bsDa2hqdOnXStun48ePRrFkzFBUVQSaTsQfSyPA6yTSZyrWSQuoC6N/hQnl5eZDL5bC2tgYAKJVKKBQKODs747333oNcLsf69evh6OiIadOmwdHRUdrC6YFEUYQgCEhJSYGNjQ2cnZ0r3N+hQwe4uLggIyMDAC/CjY0oilAoFCgsLETr1q3x5JNPYtasWfjqq6+gVqsxffp03L59G1lZWWjTpo3U5dJDaN6rKpUKgiAgNzdXe9+LL76IEydOwMHBAUqlEjt37sTAgQPx8ssvIzAwUMKq6WE0bZqamgqlUomSkpIK93t4eCApKQlPP/001Go1+vbti/79+6N58+YSVUyPorkeys/P53WSCVGpVJDL5UhNTTWJayXDrq6B0LxIBg0ahJSUFPz2228Ayr8l1aRyMzMzvPPOOxgzZgxWrVqFv//+G4Dhp/aGSvPN54ABA3Dp0iVs27atwu0KhQJyuRw5OTlSlUh1oFarYW1tjQ4dOuDo0aNo0aIF3n33Xfj5+WHJkiX45JNP8OSTT+LkyZOVLujIsGjekx07doRarcbBgwcBlE+Ev3DhAhYvXozNmzdj06ZNePbZZ7F//3589913SElJkbJseghNm44ZMwZZWVlYtmwZrl+/jjt37mD9+vU4ceIERFGEubk5VCoVvvjiCyxYsAA3b96UuHJ6kP9v796jorjuOIB/YZf3QwEJoCKUxy6KEB7CgoYYQNNj4rOaAqKNaBo9GIMnmkqMJZ4GLbTE+gpqU0EqDyGKNqmNj0SMKURjJYDgK4FUCFEQqYKALrDTP+xOXRFZxLhAvp+/3DvX2Xvnd3a4v7kzd6TSu3MAjzJO4isv+i+JRAJg8IyVOFOlQ5WVlaivr8fw4cNhaWkJf39/BAQEYOfOnfjZz36GyZMnQ19fX5zJMjQ0xGuvvYbLly8jKSkJQUFBsLCw0HU36B73xtTGxgYhISGYOHEiRowYoVHPyMgIBgYGaG9vh0qlgiAI4smlvb2dK431I5WVlairq8OIESNgYWEBa2tr8ULIqFGjsHfvXiiVSgQGBuIPf/gD4uLikJOTA0dHR8ybNw9GRkZcvKIfuve3am5uDldXV0yZMgVZWVnw9PREY2MjZsyYgfDwcHFAt2rVKkilUnzwwQeYM2cO7OzsxFkR0r17Yzp06FCEh4dj3rx5yMrKwvHjx2FgYIBr165h0aJFmD9/Puzt7QEAW7duxdatWxESEgJXV1fGtB9Zs2YNnJycxIWAnJ2dERgYyHHSAHd/XMeMGYPnnnsOI0eO1Kg30MZK/CuvIytWrMCCBQsQExODF198EW+99RYaGxvxxhtvoKOjA1u2bEFRUREAiCcMALC3t8esWbNw9epVFBcX67ILdJ/7Y7py5UoYGhpix44dCAgI0Kjb2tqKO3fuwMjICPr6+uJJoqqqCnl5ebxi2k+oY7pw4UK8+OKLWL16NS5evCgOuPz9/dHZ2SnemmBqaopr167B1NQUtbW1yMnJAaD5Gybdu/+3+vbbb6OmpgavvvoqjI2NsWXLFnz88ccwNzeHVCpFR0eHGL/o6GhYWVnh73//u457Qfe6P6arVq1CXV0d3nrrLeTm5iI+Ph6TJk3CsGHDMG3aNDGhUqlUePXVV+Hu7o4jR47ouBd0r7q6Ouzduxf79+/H7t27AQAODg5YsGABVCoVx0kD1IPi6ufnh5SUFIwbN06j7kAbKzGp0oHf/OY3KC4uxvz585GRkYHIyEgcP34cSUlJ8PX1xerVq3Hp0iWkpKSgsLAQwN0ThlKphEQiwZQpU9DZ2ckHMfuR7mKanJyMlpaWLgNqQRDEW8jUKisrkZiYiNTUVJiZmT3pLtB9uotpamoqWltbAQBubm74z3/+g+rqapw/fx5z5sxBSEgI1q9fDxcXF/EKOND/7wX/qegurikpKfDw8MAbb7yBb775Bjdv3hSTZalUKt5CZG9vDzMzM/E3zRkN3esuphs2bEBLSws8PT0xc+ZMNDY2AgA8PDwA3L3SrZ7d0NfXF696M6a619nZCQsLC4wcORJVVVXYvXs3MjMzAQBhYWGIj4/nOGkAelhczc3NB/xYibf/PWHfffcdioqKMHfuXCxYsACGhoZQKBRobm7GZ599hlu3bmH27NkwNjbGihUrsH79eixZsgTTpk0TV7opLS2FpaWleKWNdOthMS0oKADw/wG1+raStrY23L59Wyy/dOkS3nvvPZSUlCAzM5Ox1bGeYir87/V+lpaWcHFxwYEDB/DZZ5/B398f8fHxcHBwgK2tLZYvX46cnBzMmzePD0z3A9qcf3/xi1/A1NQUy5cvR3Z2NpycnPDyyy+LA+6SkhJ0dnbC2dkZAHirmI5pc/5Vs7KyQkNDA44cOYLnn39ejGlxcTFu3bqF8ePHi79txlS31ItRBAQEwNzcHFeuXMGmTZugp6eH6OhozJ49G+3t7Vi7di3HSQNId3GVSCSIiorSuJUTwIAbKzGpesIaGhrQ0NAgLgeqntaUyWQ4evQoTp06hfr6egQHB2PdunV4//33kZCQgNLSUoSHh6O+vh4HDx6Eubk5VxXrJ3qK6enTp3HlyhW4uLjA19cXhoaGkEgkkEgk6OzsRFVVFVJSUnD69Gnk5OSIV1FJd7SNqUKhwIQJE7Br1y688MILWLlypXiS9/HxwaZNm2Btbc2Eqp/Q9vwbFBSEpKQkJCcn4/e//z3Ky8uhUCjQ1NSEgoIC3L59G9OnTwfAwbeuaftb9fT0xPjx45GXl4fU1FTcuXMH4eHhKCwsRG5uLtra2hAVFcV49hPqixUWFhawtbXF1q1bERkZic2bNwMAoqKiEBkZCX19fWzfvh2//e1vUVZWhrCwMI6T+rHu4rpx40YAQEREBPT19dHW1gYTExNIJBLxToGBMFZiUvWEOTg4wNDQEEePHoVCoYCRkRGAu9OZra2teOedd9DQ0AAAiI2NxZIlS1BWVob9+/cjMzMTZmZmsLW1RWpqar/L0H+qeorpmjVrxJhGRETglVdegaWlJczMzFBTU4PExER8/fXXyM7O7pcniZ+i3sR0+PDhmDVrFpYuXYrhw4cD+P9rEp5++mmd9YG66u35Ny4uDl9//TUKCgrw8ccfw9raGqNGjUJGRgZGjRqly67Q//Tmt7ps2TIsXLgQubm5ePPNNyGRSGBsbAwbGxukpaUxpv2IOrkNDQ3FRx99BFtbW+zcuRMxMTHYvHkzjI2NIZPJ0NTUhOXLl+PUqVPiMzocJ/VfD4vrxo0bYWJiAjc3N/zjH/9ATEwMLCwsBtRYiUnVE2ZhYYHg4GAolUpx5ZKTJ08iPz8f0dHReO655yCVSnH48GH8+c9/xmuvvYbExEQsXrwY5eXlsLW1hZOTE2xtbXXdFfofbWN69OhR5OXlwcLCAitXroSbmxv++c9/4vr16/32qstPlTYxlUgk+Pzzz5GVlYWhQ4dqrFrE56f6p96ef5ctW4bk5GTU1taiqqpKXNWTM4/9h7YxPXToELZt24ZVq1Zhz549KC8vx+XLlzF69Gh4e3vDzs5O112hB7CyskJzczNKS0sRGBiIjIwMxMTEICkpCc3NzQgNDcW2bdsQHh6O2NhYnD17FsOGDeM4qZ/rLq7r1q1DS0sLJk6cKD5j5e7ujhMnTgyMsZJAT1xDQ4PQ2toqfm5vbxfS09OF77//Xiy7fv26sGTJEsHLy0uorq7WRTOpF7SNaWxsrODl5SU0NTUJubm5gqenp3Dp0iVdNJl6oE1Mr127JixdulTw8vLSKKf+i+ffwUfbmC5evFjw8vISfvjhB100k3pJpVIJLS0twtSpU4WsrCyx/NChQ8Lo0aMFb29v4f3339dhC+lRaBPXbdu2ieWZmZkDZqzEy6k6YGNjAxMTE6hUKnR2dkIqlWLBggXiu4xUKhWsra0xYcIEKJVKtLS06LjF1BNtY6q+olpbW4tf/vKX+OKLL+Du7q7j1tODaBPTYcOGISgoCEqlEs3NzTpuMWmD59/BR9uYPvPMM1AqlQPmRaI/dXp6ejA1NYWNjY24dHppaSkSEhIQGBgIExMTZGRkIC8vT1xghPo/beKanp6OPXv2QBAEREdHD5ixEpMqHVKvuX//277Vtw41NjbCxsYGlpaWumgePQJtY6p+GaGVldUTbyP1Dn+ngxPjOvgwpoOLOlHy8PCAUqnEhQsX8Morr8DPzw/bt29HVlYWjIyMkJCQgPz8fB23lrSlbVzXrl2LvXv3Ahg4YyUmVf2A+mVm3377rVh24cIFFBYWws3NjX8ABqCeYjpkyBBdNY0eEX+ngxPjOvgwpoODelEDX19fnDhxArNnz8a4cePwzjvvwMDAAK6urvjggw/g5OQEPz8/HbeWtNWbuPr7++u4tb2jJ3DOtF9IT0/H9u3bMWHCBJiYmKCiogK1tbXIzs4eEFOe1BVjOvgwpoMT4zr4MKaDR11dHSIjIxESEoLFixeLt3V2dHRAKpVCqVSK76eigWMwxpWr//UTPj4+cHZ2xr/+9S9IpVLI5XKkpKTAzc1N102jR8SYDj6M6eDEuA4+jOngYWdnh+zsbOjr62us0iiV3h3Cql/iTAPLYIwrZ6r6kTt37qCjowMdHR0wNjYW37dBAxdjOvgwpoMT4zr4MKZE9CQxqSIiIiIiIuoDLlRBRERERETUB0yqiIiIiIiI+oBJFRERERERUR8wqSIiIiIiIuoDJlVERERERER9wKSKiIiIiIioD5hUERERERER9QGTKiIiIiIioj5gUkVERA8VHx8PuVyOgoKCB26fPXs25HI5oqOjH7j9wIEDkMvl2LBhw4/ZTISFhWHcuHE/6nfoQn5+PuRyOXbt2qXrphARUTeYVBER0UMpFAoAQElJSZdtN27cwLlz56Cvr4/S0lK0tLR0qXPmzBkAQHBw8I/aTiIiIl1hUkVERA+lTqpKS0u7bPvyyy+hUqkwefJktLe346uvvupS58yZMzAyMoKfn9+P3lYiIiJdYFJFREQPNXz4cDg6OqKsrAwqlUpjW1FREaRSKZYuXQoAKCws1Nh+48YNVFVVwdfXF0ZGRk+szURERE8SkyoiIuqRQqFAS0sLvvnmG43ywsJCeHt7Qy6Xw9HREUVFRRrbi4uLIQhCl1v/vvzyS8TExMDf3x8+Pj6IiIjAoUOHHvjdFRUViI2NhUKhgLe3N2bMmIGcnBwIgtBju/Pz8+Hh4YEZM2bgxo0b3dY7deoU5HI58vPzsXfvXkybNg1eXl549tlnkZycjLa2ti51161b12U/6ufPzp8/L5bJ5XK8/fbb+OqrrzB37lw8/fTTeOaZZ7BhwwZ0dnbi22+/xaJFi+Dr64uQkBC8++67Gt+nJggCUlNTMXHiRHh7e2POnDndHjNtju/3338PuVyOTZs2ITExET4+PlAoFPjkk096OqxERHQfJlVERNSjwMBAAJrPVV2+fBm1tbUYP348AGD8+PGorKxEXV2dWOdBz1N9+OGHiImJwcWLF/HCCy8gIiIC169fR1xcHLZv367xvZ9//jkiIyNx8uRJhIaGYt68eVCpVFi7di0SEhIe2uajR49izZo1cHNzQ3p6OoYOHdpjPzMzM7F27Vq4u7tj/vz5MDIyQlpaGtasWdPj/32Y0tJSLFy4ENbW1oiKioKhoSF27NiBhIQEREVFQaVSISoqCkOGDEFmZib+9Kc/ddnHzp07sWPHDoSEhGDmzJmoqalBXFwccnJyNOr15vgCQF5eHj755BNERUXBx8cHPj4+feorEdFPkkBERNSDq1evCjKZTIiPjxfLsrKyBJlMJpw+fVoQBEE4ePCgIJPJhH379ol1IiIiBH9/f6Gjo0MQBEG4cuWKMHbsWGHKlClCY2OjWK+trU2IiIgQPDw8hIsXLwqCIAitra1CUFCQEBwcLNTU1Ih1Ozs7hWXLlgkymUw4fvy4WB4aGir4+/sLgiAIRUVFwtixY4Wf//znQn19fY/9O3nypCCTyYTRo0cLxcXFYnlTU5MQFBQkjBkzRrh165ZG3cTExC77WbVqlSCTyYRz586JZTKZTJDJZEJ6erpYVllZKZYnJSWJ5c3NzYKfn58QHBwslu3bt0+QyWTCmDFjhLNnz4rlNTU1woQJEwQfHx/h5s2bvT6+NTU1gkwmE+RyuXD+/PkejxEREXWPM1VERNQjOzs7ODs7a8xUFRUVwdTUVJzZCAoKgp6enngLoFKpREVFBQICAiCRSAAAH330EZRKJV5//XVYWVmJ+zI2Nsbrr78OlUqF/fv3AwCOHTuGxsZGLFq0CCNHjhTr6uvrY8WKFQCAffv2dWlrWVkZYmNjYW9vj4yMDNja2mrdz4CAAPj6+oqfLSws4Ovri46ODly9elXr/dzP0NAQc+fOFT+7uLiI/V+4cKFYbm5uDldXV1y/fh23b9/W2Mf06dMxduxY8fPIkSPxq1/9Cq2trfj0008B9O74qjk5OcHDw+OR+0ZERIBU1w0gIqKBQaFQIC8vD01NTTAzM8OpU6cQGBgIqfTunxJra2t4eHiIKwCWlZVBqVRq3PpXXl4O4O4zP/c/n9Xa2goAuHDhgkbdiooKbNmypUt7JBKJWFft9u3b+PWvf43W1laMHj0adnZ2veqjs7NzlzILCwsAQHt7e6/2dS8HBwcYGhpqlJmamqKtra1L0qde0EOpVMLY2Fgsf9DqiV5eXgC6HjNtjq/avQkrERE9GiZVRESkFYVCgdzcXJSUlMDS0hJNTU1dFqAIDg5GWloaqqurUVxcLJapNTc3AwD27NnT7ffcvHlTo+7Bgwd7rKvW3t4OAwMDeHl54fDhwygoKEBoaKjWfbw/8QEAPT09ANBqYYzumJiYPLDcwMBA633Y2Nh0KTMzMwPw/4SpN8dXjasyEhH1HZMqIiLSinqxivLycujr3717vLukqri4GMXFxbC1tYW7u7u43dTUFADw6aefwtHR8aHfp667a9curV8cbGBggIyMDAiCgJkzZ+J3v/sdAgMDxeTjcXhYkvWgVfsel6ampi5l9fX1AIAhQ4YA6N3xJSKix4fPVBERkVZsbW3h4uKCiooKnDlzBsOGDYNcLteoExAQAAMDA1y8eBGlpaXii4PV1PXPnj3bZf///ve/kZycjGPHjmnUVd/Sdq8bN25g3bp1+Nvf/qZRbmxsDFdXV7i5ueHll1/GDz/8gE2bNj16px9APbuknh26V01NzWP9rns96Dion3Hz9PQE0LvjS0REjw+TKiIi0ppCocDZs2dRUlKCoKCgLttNTEzg4+ODgoICNDY2dplhmj59OiQSCTZu3Ihr166J5R0dHXj33XeRlpYmvk9q8uTJMDc3x1/+8hd89913Gvv54x//iL/+9a+orq7utq1Lly6Fg4MDMjMzH5iQPConJydIJBKcPHlSY2bq+PHjqKioeGzfc78DBw7g8uXL4ufKykpkZ2fDysoKYWFhAHp3fImI6PHh7X9ERKQ1hUIhvhdJ/X6q+wUHB2Pz5s3iv+/l7OyMN998E0lJSZg6dSrCwsIwZMgQnDhxApWVlQgNDcX06dMBAJaWlkhMTMTKlSsxa9YsTJo0CU899RROnz6NsrIyeHl5aaycdz9TU1OsXr0ay5YtQ0JCAj788ENxFcK+sLa2xqRJk3D48GG89NJLmDhxImpqanDs2DH4+/uL7+Z63KytrfHSSy9h6tSpuH37Ng4fPow7d+7gvffeExe06M3xJSKix4dJFRERaU2hUEBPTw+CIPSYVDk6OmLEiBFdtsfExMDFxQVpaWk4cuQIVCoVHB0dER8fj+joaHE1QQCYMmUK7O3tsWPHDnzxxRdoa2vDiBEjEBsbi0WLFvX4rNTzzz+PZ599FidOnEBGRsZDk7DeWL9+PZ566ikcOnQIu3fvhru7OzZv3ozq6uofLalavnw5zp07h/z8fLS0tMDb2xtxcXEYN26cRr3eHF8iIno89IS+LGdERERERET0E8dnqoiIiIiIiPqASRUREREREVEfMKkiIiIiIiLqAyZVREREREREfcCkioiIiIiIqA+YVBEREREREfUBkyoiIiIiIqI+YFJFRERERETUB0yqiIiIiIiI+oBJFRERERERUR8wqSIiIiIiIuoDJlVERERERER9wKSKiIiIiIioD/4LDdWGpOZ6iZAAAAAASUVORK5CYII=",
+      "text/plain": [
+       "<Figure size 1000x600 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "plt.figure(figsize=(10, 6))\n",
+    "plt.plot(week_count[\"week_number\"], week_count[\"reviewId\"])\n",
+    "plt.xlabel('Week number')\n",
+    "plt.ylabel('Count')\n",
+    "plt.title('Number of Negative Reviews on Login Over Time')\n",
+    "plt.xticks(rotation=45)\n",
+    "plt.grid(True)\n",
+    "\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 335,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[Text(0.5, 0, 'Topic'),\n",
+       " Text(0, 0.5, 'Count'),\n",
+       " Text(0.5, 1.0, 'Distribution of Topics')]"
+      ]
+     },
+     "execution_count": 335,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAABOwAAALUCAYAAAC4vK1/AAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjcuMSwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy/bCgiHAAAACXBIWXMAAA9hAAAPYQGoP6dpAABvB0lEQVR4nOzdd5hV1d024GcKHWkKRBQjasSKqIiVFyyxd40NC/YCGondoDFGjRq7olGDjaiJLRqVGGvsvWtULK9RRGEiCNIEZub7w2/OC4KCCM6Gue/r8hL2Xufs317sM3POc9Zeq6y2trY2AAAAAEAhlNd3AQAAAADA/xHYAQAAAECBCOwAAAAAoEAEdgAAAABQIAI7AAAAACgQgR0AAAAAFIjADgAAAAAKRGAHAAAAAAUisAMAAACAAhHYAQAN2qWXXpquXbvO9N9KK62U7t27Z/PNN88pp5yS999/f5bHjRgxIl27ds0RRxwxT8d97bXX8sQTT3yvGh988MH5cuw5eeKJJ/Laa6+V/v7ss8+ma9euOfPMMxfI8ea36dOn55xzzsmGG26Y1VdfPdttt91s233z3/27/rvjjjsWSK2bbLJJevTosUCeGwBYeFXWdwEAAEWw6aabZuWVV06S1NTUZMKECXn77bdzyy235O9//3suvvji9OnTp9S+VatWGTBgQJZbbrnvfax//etfOfzww3PCCSdko402mmP7nj17ZsCAAenSpcv3Ptb3ddNNN+W3v/1tBg8eXNq21FJLZcCAAVljjTUW+PHnh9tuuy3XXHNNunTpkp122imLL774bNsNGDBgpr9/8skn+dvf/paVVlopm2222Uz76q6N+W3ffffN1KlTF8hzAwALL4EdAECSzTbbLDvvvPMs2x999NH0798/AwcOzJ133pmf/vSnSb4O7I488sh5OtaYMWNSU1Mz1+3XXXfdrLvuuvN0rO/r888/n2Xb0ksvPc/nWh/+/e9/J0lOPfXUbLDBBt/a7pvn9Oyzz+Zvf/tbVl555R/tfPv16/ejHAcAWLi4JRYA4Dv07t07v/zlLzNp0qRcfvnl9V0Oc6FuxFrbtm3ruRIAgHkjsAMAmIO99947TZo0yf3335/p06cnmf08ctOnT89ll12W7bbbLt27d0/Pnj1z4IEH5umnny61OfHEE3PSSSclSX7/+9+na9euGTFiRGmeuJtuuim/+tWv0q1bt2y00UZ58cUXZ5nDbkb3339/tttuu6y++urZYostcuWVV2batGkztenatWt22GGHWR57xx13pGvXrrnuuuuSJPvss08uu+yyJEn//v3TtWvXJN8+h93//u//5thjj80GG2yQ1VZbLZtttlnOPffcfPnllzO1O/HEE9O1a9eMGzcuv/nNb0pzy+2888755z//OVf/Bkny5JNPZv/9989aa62Vbt26ZaeddsqNN95YGq1Y92/yt7/9LUmy4447pmvXrnn22Wfn+hjfZdiwYdljjz3SvXv3rLnmmtljjz1y7733ztKua9euOfbYY/PMM89k1113Tbdu3bLJJpvkwgsvzFdffTVT29nNYVddXZ1rr70222+/fbp3757evXvnuOOOy8cffzxTu3vuuSd77LFH1llnnay55prZZZddctNNN6W2tna+nC8AUH8EdgAAc9CsWbOsssoqmTRpUt56661vbfe73/0ul156adq0aZO+fftmyy23zKuvvpoDDzywFBptttlm2XTTTZMkG220UQYMGJBWrVqVnmPw4MF5/fXXs/fee2eVVVbJqquu+q3He+WVV/LLX/4ynTt3zp577pmysrJccMEFOf744+fpPHfaaaf07NkzSbL11lvPMsfbjF599dXsvPPOuffee9O9e/f07ds3iy++eIYMGZLddtstX3zxxSyP2X///fP4449nq622ynbbbZd33303v/zlL+dq8Y2hQ4fmgAMOyOuvv56f//zn2WWXXfLll1/m9NNPzzHHHJPa2trSvIIrrbRSkmT33XfPgAEDstRSS81Tf8zonHPOycCBAzNixIhsu+222WabbTJixIj86le/yh/+8IdZ2r/zzjs56KCD0qxZs/Tt2zetW7fOH//4xxxyyCHfeTt0TU1NDj300Jx99tmprq7Orrvumh49emTYsGHZa6+9MmrUqCTJvffem2OOOSZjx47NTjvtlN133z3jx4/Pb3/7WyNBAWARYA47AIC50LFjxyRJVVXVbPdPmDAht9xyS9ZZZ50MHTq0tP0Xv/hFdt1119x4441Zd911s9lmm2X8+PF56KGH0qtXr1nmMJs4cWLuvPPOtG/ffo41ff755/n1r3+dfffdN0nyq1/9KoceemiGDRuWXXfdNRtuuOH3Osedd945n3zySZ577rlss802syy8UKe6ujrHH398pk6dmiuvvDL/8z//U9p33nnn5eqrr865556bs846a6bHVVRU5J577knz5s2TJOuvv36OPfbY3H777d+5+MbHH3+cs88+O506dcoNN9yQzp07J0kmTZqUww8/PMOGDUvv3r2z44475sgjj8wnn3ySt99+O3vuued8WSzihRdeyDXXXJNVVlklQ4YMSbt27ZJ8PRfhfvvtlz/96U/p06dP1llnndJjhg8fnr59++bUU09N8vXoy6OPPjoPPPBA7rzzztnOl5h8Perx8ccfz5Zbbpk//OEPady4cZJk4403zjHHHJOrr746gwYNypAhQ9K8efPcfvvtadmyZZKvF9HYcsst8+c//zlHHHFEysrKfvC5AwD1wwg7AIC5UBecTJgwYbb7a2pqUltbm08//XSmUG/11VfPgw8+mPPPP3+ujrPWWmvNVViXJMsss0z69u1b+nvTpk0zcODAJMndd989V88xL15++eV8+OGH2WabbWYK65LkqKOOSseOHXP33XfPsvpp3759S2Fd8vX8gMnXq7N+l7///e+ZPn16+vfvXwrrkqR58+YZNGhQkuT222//Qef0Xe64444kyfHHH18K65KkXbt2OeaYY2Z7/ObNm+eXv/xl6e+VlZWlkY/f9W9Td4vtySefXLrmkmSbbbbJYYcdlrXWWitJUltbmylTpuTdd98ttWnZsmVuu+22PPTQQ8I6AFjICewAAObCxIkTk2SmwGlGrVq1ytZbb50RI0Zk4403zj777JOrr7467733Xjp37pxGjRrN1XGWXnrpua5pjTXWSEVFxUzbVl111ZSXl+ftt9+e6+f5vupuC55xRFmdxo0bZ/XVV8/UqVPzwQcfzLSvS5cuM/19scUWS5JZgr1vqjuX2R3vZz/7WVq1arVAz/ftt99OeXl51l577Vn21W375vG7du2a1q1bz7RtmWWWSZs2bb6z1rfffjudOnUqjeisU1ZWloEDB2brrbdO8vXtvjU1Ndljjz2y/fbb57zzzsvzzz+fDh06fOs1CgAsPAR2AABzoW4U2IwjvL7pnHPOyQknnJBll102zz33XM4777xss8022WWXXb5z7rsZNWnSZK5rWmKJJWbZ1qhRozRp0iSTJk2a6+f5vupGGdbdivlNHTp0SJJMnjx5pu0zjhhLUhoFNqdFEuqOVxfwze543zzW/DRhwoQ0adJklvrramrWrNksx/9m4FZniSWWmGVRjhmNHz/+W/t1RnvssUcuu+yy9OzZM++9916uvvrq7L333unTp0+GDRs2x8cDAMUmsAMAmIMvvvgi7733Xlq1apUVVljhW9s1atQoBxxwQO6555488sgjOeOMM7LRRhvljTfeyKGHHjrL6q0/1Pjx42fZ9uWXX2by5MmzjO6a3UIH8xpytWjRIklKCyB8W11t2rSZp+f/vscbN27cfDvWtx1/8uTJs+3vr776KlOmTEnbtm1n2T4748ePn6XtjJo3b14azflN3wxhf/7zn2fo0KF55plnctlll2XnnXfOmDFjcswxx2T48OFzOi0AoMAEdgAAc3DLLbdk+vTp2WqrrWa5BbXOxx9/nAsuuCCPPPJIkqRTp075xS9+kSFDhmS99dbLqFGjMmLEiCSZb/OLvf7667Nse/nll5NkptVlGzVqNNtw7uOPP55l29zUVreQw0svvTTLvpqamrz44otp3rz5fFmdNUlp1dcXX3xxln3/+c9/UlVVlZ/97Gfz5Vjf9/gvvvhiamtrZwly33jjjVlC0k8++SSjR4/OGmus8a3HWnHFFTNy5MjZLm6y4447ZosttsjUqVNzxRVX5Lrrrkvy9e3YP//5z/P73/8+hx9+eGpqakrXAQCwcBLYAQB8h6effjqDBw9O8+bNc+ihh35ru6ZNm+bqq6/OxRdfPNOcbFOnTk1VVVUaN25cWkyisrIySX7wiLvhw4fnH//4R+nvEyZMyEUXXZSysrKZViFdbrnlMmLEiJkWKPjkk09y5513zvKcdbV917xya6+9dn7605/m/vvvz6OPPjrTvksuuSSffvppttpqq9neQjovdthhh1RWVuaPf/zjTCHjpEmTcvrpp5faLCh1fXnBBRdkzJgxpe1jxozJueeeO9vjV1VV5U9/+lPp79OmTcvZZ5+dJNlll12+9Vjbb799amtrc95556W6urq0/R//+Ef+85//ZP3110/jxo1zzz335OKLL54ldK27dbtTp07zcqoAQEFU1ncBAABF8OCDD5bCjpqamkyYMCH//ve/88ILL6Rp06a58MILv3PEWPv27bPffvvl2muvzbbbbpvevXunvLw8jz/+eN5///0cccQRpbnJ6uY3u/nmmzNu3Ljss88+81TzMsssk2OPPTYPPvhg2rZtm0ceeSQjRozIIYcckm7dupXa7bbbbvnd736XffbZJ9tuu22mTp2af/zjH1lxxRXzwgsvzPScdbVdccUVeeuttzJgwIBZjlteXp6zzz47Bx54YA477LBsvPHGWWaZZfLyyy/nlVdeyfLLL19aEXV+6Ny5c0444YSceeaZ2WmnnbLZZpulefPmeeyxx/Lxxx9nm222yY477jjfjvdN66yzTvbff/9ce+212X777bPxxhsnSR555JFUVVXl4IMPnmVBjObNm+fCCy/Ms88+m+WXXz5PP/10hg8fnh122KH0+NnZddddc//99+fOO+/MO++8k3XXXTejRo3K/fffn6WXXrq0CvCvfvWr9O/fPzvttFO23HLLtG7dOm+88UaeeeaZ9OzZMxtuuOEC6w8AYMET2AEAJHnooYfy0EMPlf7erFmzLLXUUtl7772z3377ZZlllpnjcxx33HH56U9/mltvvTV/+9vfUl1dnRVWWCFnn312dtppp1K7ddZZJ3379s1dd92VG2+8MRtssMG33mr7Xfr06ZNVVlklf/zjH/PJJ59k2WWXzRlnnJFf/OIXM7Xbe++9U11dnZtuuil/+ctfsuSSS+bQQw/N+uuvP9NIvCTZeuut8+ijj+Zf//pXbrrpppnqntFaa62V2267LZdffnmeeuqpPP744+nUqVMOP/zwHHzwwaV55+aXfffdN8suu2yGDBmS+++/P7W1tVl++eVz6KGHZtddd52vx5qdE088MausskpuvPHG3H333amsrMzKK6+cU089NZtvvvks7ZdZZpkcffTRufDCC/P8889n6aWXzsknn5x99933O49TUVGRK664IkOGDCldHy1btsx2222XX/3qV6W5CTfddNMMGTIkV199dR555JGMHz8+nTp1Sv/+/XPwwQenvNyNNACwMCurndOyXAAAwFzr2rVrVlpppdx11131XQoAsJDy1RsAAAAAFIjADgAAAAAKRGAHAAAAAAViDjsAAAAAKBAj7AAAAACgQAR2AAAAAFAgAjsAAAAAKJDK+i5gUVdbW5uaGtMEAgAAADR05eVlKSsrm2M7gd0CVlNTmzFjJtZ3GQAAAADUs3btWqSiYs6BnVtiAQAAAKBABHYAAAAAUCACOwAAAAAoEIEdAAAAABSIwA4AAAAACkRgBwAAAAAFIrADAAAAgAIR2AEAAABAgQjsAAAAAKBABHYAAAAAUCACOwAAAAAoEIEdAAAAABSIwA4AAAAACkRgBwAAAAAFIrADAAAAgAIR2AEAAABAgQjsAAAAAKBABHYAAAAAUCACOwAAAAAoEIEdAAAAABSIwA4AAAAACkRgBwAAAAAFIrADAAAAgAIR2AEAAABAgQjsAAAAAKBABHYAAAAAUCCV9V0AfJfy8rKUl5fVdxkLXE1NbWpqauu7DAAAAKAABHYUVnl5WVq3aZ7KikV/IOj06pqM+2KS0A4AAAAQ2FFc5eVlqawozyG33JLhVVX1Xc4Cs2L79rlqt91SXl4msAMAAAAEdhTf8KqqvDZyZH2XAQAAAPCjWPTvNQQAAACAhYjADgAAAAAKRGAHAAAAAAUisAMAAACAAhHYAQAAAECBCOwAAAAAoEAEdgAAAABQIAI7AAAAACgQgR0AAAAAFIjADgAAAAAKRGAHAAAAAAUisAMAAACAAhHYAQAAAECBCOwAAAAAoEAEdgAAAABQIAI7AAAAACgQgR0AAAAAFIjADgAAAAAKRGAHAAAAAAUisAMAAACAAhHYAQAAAECBCOwAAAAAoEAEdgAAAABQIAI7AAAAACgQgR0AAAAAFIjADgAAAAAKRGAHAAAAAAUisAMAAACAAhHYAQAAAECBCOwAAAAAoEAEdgAAAABQIAI7AAAAACgQgR0AAAAAFIjADgAAAAAKRGAHAAAAAAUisAMAAACAAhHYAQAAAECBCOwAAAAAoEAEdgAAAABQIIUM7F577bUcfPDB6dGjR1ZfffXsuOOOufPOO2dqc8EFF6Rr166z/W/8+PGldtXV1bn66quz+eabp1u3btl+++0zbNiw2R73tttuy7bbbps11lgjW2yxRW688cYFeZoAAAAAMIvK+i7gm95///3ss88+ad26dQ466KC0aNEiw4YNywknnJCxY8dm//33T5IMHz48nTt3zpFHHjnLczRr1qz053POOSfXX399dtppp3Tv3j333XdfBg4cmJqammy77baldtdff33OOuusbLLJJunbt2+eeeaZnH766ZkwYUIOPfTQBX/iAAAAAJCkrLa2tra+i5jRIYcckueffz733XdfOnbsmCSpqanJXnvtlXfeeSdPPPFEWrRokU022SRrrLFGLrzwwm99rg8//DBbbbVV+vbtm0GDBiX5esRd3759M2LEiDz88MNp3Lhxxo8fn969e2f99dfP4MGDU1ZWliQZOHBgHn744TzyyCNp167dPJ1PdXVNxoyZOE+PbegqK8vTtm2L9Bk8OK+NHFnf5Sww3Tp1yr/698/YsRMzfXpNfZcDAAAALCDt2rVIRcWcb3gt1C2x1dXVef7559OrV69SWJck5eXl2WqrrTJp0qS89dZbmTBhQkaOHJnll1/+O5/v3nvvTU1NTfr27VvaVlFRkb59+6aqqirPP/98kuThhx/OpEmTstdee5XCuiTZZ599MmXKlDz44IPz+UwBAAAAYPYKFdiVl5fn73//e44//vhZ9o0ZMybJ14Hbe++9l9ra2lJgN3ny5NTUzDoy6Y033kjLli3TpUuXmbavuuqqpf0z/n+11Vb7znYAAAAAsKAVKrArKytL586ds/TSS8+0fdKkSbn99tvTvHnzrLLKKhk+fHiS5PHHH0+fPn3SvXv3rL322jnttNMyefLk0uNGjRo100i9Oh06dEiSjPz/t1mOHj06TZs2TZs2bWZq16RJk7Rp06bUDgAAAAAWtMItOvFNtbW1GTRoUKqqqtK/f/80adKkFNi9/vrrGTBgQFq2bJlHH300N998c95///1cf/31KS8vz8SJE9OiRYtZnrNp06ZJUgr3Jk6cWNr2TU2aNJkpBJwXlZWFykUXGnNzT/eipKGdLwAAADB7hQ7samtrc9ppp+Xee+9Nz549c/jhhydJevXqlcUWWywHH3xwmjdvniTZcsst07Zt2wwZMiQPPPBAtthiiySZaU66b6rbV1tbO1ft5kV5eVnatp01NIRvatWq2ZwbAQAAAIu8wgZ206ZNy4knnph77rkn3bp1yxVXXJFGjRolSXr37p3evXvP8pi99torQ4YMyTPPPJMtttgizZs3z5QpU2ZpV7etZcuWSfKt7ZLkq6++KrWbFzU1tRk/ftI8P74hq6gob1Ah1vjxk1NdbZVYAAAAWFS1atVsru6wK2RgN3ny5Bx55JF5/PHH07Nnz1xxxRVzFZotvvjiSb6e8y5JOnXqVFoJdkajR49OktL8dp06dcrkyZMzYcKEmY7z1Vdf5YsvvijNeTevpk8XwjBn1dU1rhUAAACgWItOJF+PrBswYEAef/zxbLzxxvnTn/40S1jXr1+/HHDAAbM89oMPPkiSdO7cOcnXq7yOGzcuH3/88Uzt3nzzzSTJ6quvXmqXzLoa7DfbAQAAAMCCVrjA7pJLLskTTzyRTTbZJJdeemmaNGkyS5s2bdrkqaeeyssvv1zaVlNTk8suuywVFRXZeuutkyRbbLFFysrKcsMNN5TaVVdX58Ybb0zHjh3To0ePJEmfPn3SrFmzDB06dKbjDB06NE2bNs1mm222IE4VAAAAAGZRqFtiR48enWuvvTaVlZXZaKONMmzYsFnarL/++jn22GPz5JNP5uCDD84+++yTdu3a5Z///Geef/75HH300VluueWSJMsvv3x233333HDDDZk4cWK6d++eYcOG5eWXX86FF15YmhOvdevWOeKII3L++eenf//+6dOnT5544oncd999OfbYY9O2bdsftR8AAAAAaLgKFdi99NJLmTZtWpLk9NNPn22bq6++Ov/zP/+Tm266KRdddFGGDh2aqVOnZoUVVsg555yTHXfccab2p5xySpZYYoncfvvtuffee9OlS5dccsklpVVk6xxyyCGlUXaPPfZYll566Zx22mnZc889F8i5AgAAAMDslNXW1tbWdxGLsurqmowZM7G+y1goVVaWp23bFukzeHBeGzmyvstZYLp16pR/9e+fsWMnWnQCAAAAFmHt2rWYq1ViCzeHHQAAAAA0ZAI7AAAAACgQgR0AAAAAFIjADgAAAAAKRGAHAAAAAAUisAMAAACAAhHYAQAAAECBCOwAAAAAoEAEdgAAAABQIAI7AAAAACgQgR0AAAAAFIjADgAAAAAKRGAHAAAAAAUisAMAAACAAhHYAQAAAECBCOwAAAAAoEAEdgAAAABQIAI7AAAAACgQgR0AAAAAFIjADgAAAAAKRGAHAAAAAAUisAMAAACAAhHYAQAAAECBCOwAAAAAoEAEdgAAAABQIAI7AAAAACgQgR0AAAAAFIjADgAAAAAKRGAHAAAAAAUisAMAAACAAhHYAQAAAECBCOwAAAAAoEAEdgAAAABQIAI7AAAAACgQgR0AAAAAFIjADgAAAAAKRGAHAAAAAAUisAMAAACAAhHYAQAAAECBCOwAAAAAoEAEdgAAAABQIAI7AAAAACgQgR0AAAAAFIjADgAAAAAKRGAHAAAAAAUisAMAAACAAhHYAQAAAECBCOwAAAAAoEAEdgAAAABQIAI7AAAAACgQgR0AAAAAFIjADgAAAAAKRGAHAAAAAAUisAMAAACAAhHYAQAAAECBCOwAAAAAoEAEdgAAAABQIAI7AAAAACgQgR0AAAAAFIjADgAAAAAKRGAHAAAAAAUisAMAAACAAhHYAQAAAECBCOwAAAAAoEAEdgAAAABQIAI7AAAAACgQgR0AAAAAFIjADgAAAAAKRGAHAAAAAAUisAMAAACAAhHYAQAAAECBCOwAAAAAoEAEdgAAAABQIAI7AAAAACgQgR0AAAAAFIjADgAAAAAKRGAHAAAAAAUisAMAAACAAhHYAQAAAECBCOwAAAAAoEAEdgAAAABQIAI7AAAAACgQgR0AAAAAFIjADgAAAAAKRGAHAAAAAAUisAMAAACAAhHYAQAAAECBCOwAAAAAoEAEdgAAAABQIAI7AAAAACgQgR0AAAAAFIjADgAAAAAKRGAHAAAAAAVSyMDutddey8EHH5wePXpk9dVXz4477pg777xzpjZTpkzJeeedl4033jhrrLFGdt999zz99NOzPFd1dXWuvvrqbL755unWrVu23377DBs2bLbHve2227LttttmjTXWyBZbbJEbb7xxQZweAAAAAHyrwgV277//fvbZZ5+88847Oeigg3L88cenWbNmOeGEE3LttdeW2h1zzDG55pprsummm+aEE07ItGnTctBBB+WFF16Y6fnOOeecnHfeeVlrrbVy8sknp127dhk4cGDuueeemdpdf/31+fWvf53OnTvnxBNPzEorrZTTTz89V1555Y9y3gAAAACQJGW1tbW19V3EjA455JA8//zzue+++9KxY8ckSU1NTfbaa6+88847eeKJJ/Laa6+lX79+Oemkk9KvX78kyaRJk7L99tunVatWueOOO5IkH374Ybbaaqv07ds3gwYNSvL1iLu+fftmxIgRefjhh9O4ceOMHz8+vXv3zvrrr5/BgwenrKwsSTJw4MA8/PDDeeSRR9KuXbt5Op/q6pqMGTPxB/ZKw1RZWZ62bVukz+DBeW3kyPouZ4Hp1qlT/tW/f8aOnZjp02vquxwAAABgAWnXrkUqKuY8fq5QI+yqq6vz/PPPp1evXqWwLknKy8uz1VZbZdKkSXnrrbdy9913p1GjRtltt91KbZo3b55dd901b775Zj788MMkyb333puampr07du31K6ioiJ9+/ZNVVVVnn/++STJww8/nEmTJmWvvfYqhXVJss8++2TKlCl58MEHF/CZAwAAAMDXChXYlZeX5+9//3uOP/74WfaNGTMmydeB2xtvvJEuXbqkefPmM7VZddVVkyRvvPFG6f8tW7ZMly5d5tguSVZbbbXvbAcAAAAAC1plfRcwo7KysnTu3HmW7ZMmTcrtt9+e5s2bZ5VVVsmoUaPSrVu3Wdp16NAhSTLy/98+OWrUqJlG6n1bu9GjR6dp06Zp06bNTO2aNGmSNm3alNoBAAAAwIJWqMBudmprazNo0KBUVVWlf//+adKkSSZOnJhmzZrN0rZp06ZJksmTJydJJk6cmBYtWsxVu7pt39SkSZNSu3lVWVmogYwLjbm5p3tR0tDOFwAAAJi9Qgd2tbW1Oe2003LvvfemZ8+eOfzww+fqcTPOQzfjn7+tXW1t7Vy1mxfl5WVp23bW0BC+qVWrWUNoAAAAoOEpbGA3bdq0nHjiibnnnnvSrVu3XHHFFWnUqFGSrxeYmDJlyiyPqdvWsmXL+dIuSb766qtSu3lRU1Ob8eMnzfPjG7KKivIGFWKNHz851dVWiQUAAIBFVatWzebqDrtCBnaTJ0/OkUcemccffzw9e/bMFVdcMVNo1qlTp1RVVc3yuNGjRydJad66Tp06lVaCnVO7yZMnZ8KECTMd56uvvsoXX3xRmvNuXk2fLoRhzqqra1wrAAAAQLFWiU2+Hlk3YMCAPP7449l4443zpz/9aZYRbquuumree++9WUbFvfnmm0mS1VdfvdRu3Lhx+fjjj+fYLpl1NdhvtgMAAACABa1wgd0ll1ySJ554IptsskkuvfTSNGnSZJY2W265ZaZOnZq//OUvpW2TJk3Kbbfdlm7dumWZZZZJkmyxxRYpKyvLDTfcUGpXXV2dG2+8MR07dkyPHj2SJH369EmzZs0ydOjQmY4zdOjQNG3aNJttttmCOFUAAAAAmEWhbokdPXp0rr322lRWVmajjTbKsGHDZmmz/vrrp1evXunVq1f+8Ic/5NNPP02XLl1yyy235LPPPsvZZ59darv88stn9913zw033JCJEyeme/fuGTZsWF5++eVceOGFpTnxWrdunSOOOCLnn39++vfvnz59+uSJJ57Ifffdl2OPPTZt27b90foAAAAAgIatUIHdSy+9lGnTpiVJTj/99Nm2ufrqq9OhQ4dcfPHFufDCC3P33Xdn8uTJ6dq1a4YMGVIaNVfnlFNOyRJLLJHbb7899957b7p06ZJLLrkkW2yxxUztDjnkkNIou8ceeyxLL710TjvttOy5554L5mQBAAAAYDbKamtra+u7iEVZdXVNxoyZWN9lLJQqK8vTtm2L9Bk8OK+NHFnf5Sww3Tp1yr/698/YsRMtOgEAAACLsHbtWszVKrGFm8MOAAAAABoygR0AAAAAFIjADgAAAAAKRGAHAAAAAAUisAMAAACAAhHYAQAAAECBCOwAAAAAoEAEdgAAAABQIAI7AAAAACgQgR0AAAAAFIjADgAAAAAKRGAHAAAAAAUisAMAAACAAhHYAQAAAECBCOwAAAAAoEAEdgAAAABQIAI7AAAAACgQgR0AAAAAFIjADgAAAAAKRGAHAAAAAAUisAMAAACAAhHYAQAAAECBCOwAAAAAoEAEdgAAAABQIAI7AAAAACgQgR0AAAAAFIjADgAAAAAKRGAHAAAAAAUisAMAAACAAhHYAQAAAECBCOwAAAAAoEAEdgAAAABQIAI7AAAAACgQgR0AAAAAFIjADgAAAAAKRGAHAAAAAAUisAMAAACAAhHYAQAAAECBCOwAAAAAoEAEdgAAAABQIAI7AAAAACgQgR0AAAAAFIjADgAAAAAKRGAHAAAAAAUisAMAAACAAhHYAQAAAECBCOwAAAAAoEAEdgAAAABQIAI7AAAAACgQgR0AAAAAFIjADgAAAAAKRGAHAAAAAAUisAMAAACAAhHYAQAAAECBCOwAAAAAoEAEdgAAAABQIAI7AAAAACgQgR0AAAAAFIjADgAAAAAKRGAHAAAAAAUisAMAAACAAhHYAQAAAECBCOwAAAAAoEAEdgAAAABQIAI7AAAAACgQgR0AAAAAFIjADgAAAAAKRGAHAAAAAAUisAMAAACAAhHYAQAAAECBCOwAAAAAoEAEdgAAAABQIAI7AAAAACgQgR0AAAAAFIjADgAAAAAKRGAHAAAAAAUisAMAAACAAhHYAQAAAECBCOwAAAAAoEAEdgAAAABQIAI7AAAAACgQgR0AAAAAFIjADgAAAAAKRGAHAAAAAAUisAMAAACAAhHYAQAAAECBCOwAAAAAoEAEdgAAAABQIAI7AAAAACiQBRrYTZ06NR9++OGCPAQAAAAALFLmObBbeeWVM3jw4O9sc9lll+UXv/jFvB4CAAAAABqcyrlt+MYbb2TUqFGlv9fW1uaDDz7IQw89NNv206ZNy7/+9a9Mnz79h1cJAAAAAA3EXAd248aNS//+/VNWVpYkKSsry7BhwzJs2LBvfUxtbW223nrrH14lAAAAADQQcx3Ybbjhhjn11FMzZsyY1NbWZvDgwVlnnXWy7rrrzrZ9o0aN0rFjxx8c2F111VW5/vrr8+STT86y74ILLsiVV14528c9//zzadWqVZKkuro611xzTW699dZ89tlnWXbZZXPYYYfNtrbbbrst1113XT7++OP85Cc/yb777pu+ffv+oHMAAAAAgLk114Fdkuy1116lPz/33HPZZZddsuOOO87vmkoeffTRXHLJJWnduvVs9w8fPjydO3fOkUceOcu+Zs2alf58zjnn5Prrr89OO+2U7t2757777svAgQNTU1OTbbfdttTu+uuvz1lnnZVNNtkkffv2zTPPPJPTTz89EyZMyKGHHjr/TxAAAAAAvqGstra2tr6L+Kba2trceOONOfvsszNt2rQsscQSsx1ht8kmm2SNNdbIhRde+K3P9eGHH2arrbZK3759M2jQoCRfj7jr27dvRowYkYcffjiNGzfO+PHj07t376y//voZPHhw6dbfgQMH5uGHH84jjzySdu3afe9zqa6uyZgxE7/340gqK8vTtm2L9Bk8OK+NHFnf5Sww3Tp1yr/698/YsRMzfXpNfZcDAAAALCDt2rVIRcWc14D9XiPsvmns2LG5//7788knn2Tq1KmZXfZXVlaWE0888Xs97+67755XX301G220UcaOHTvTYhd1JkyYkJEjR2bnnXf+zue69957U1NTM9NtrRUVFenbt2+OPfbYPP/889lwww3z8MMPZ9KkSdlrr71KYV2S7LPPPhk2bFgefPDB7Lbbbt/rPAAAAADg+5rnwO7tt9/Ofvvtl/Hjx882qKszL4HdyJEjc/rpp2e33XbLvvvuO9s27733Xmpra7P88ssnSSZPnpwmTZqkvHzmlPKNN95Iy5Yt06VLl5m2r7rqqqX9G264Yd54440kyWqrrfat7QR2AAAAACxo8xzYXXDBBRk3blx22223/M///E8WW2yxmUam/RB1t6l+l+HDhydJHn/88Zxzzjn59NNP07x58+ywww454YQTSnPYjRo1Kh07dpzl8R06dEjydTiYJKNHj07Tpk3Tpk2bmdo1adIkbdq0KbWbF5WVcx7qyKzmZojooqShnS8AAAAwe/Mc2L3wwgvZeOONc/rpp8/PepJkjmFd8n+B3euvv54BAwakZcuWefTRR3PzzTfn/fffz/XXX5/y8vJMnDgxLVq0mOXxTZs2TfL1yLwkmThxYmnbNzVp0qTU7vsqLy9L27azHh++qVWrZnNuBAAAACzy5jmwKy8vz3LLLTc/a/leevXqlcUWWywHH3xwmjdvniTZcsst07Zt2wwZMiQPPPBAtthiiyT5zpF/dftqa2vnqt33VVNTm/HjJ83TYxu6ioryBhVijR8/OdXVFp0AAACARVWrVs0W7KITPXr0yAsvvDCvD//Bevfund69e8+yfa+99sqQIUPyzDPPZIsttkjz5s0zZcqUWdrVbWvZsmWSfGu7JPnqq69K7eaFlT+ZG9XVNa4VAAAAIPM8adZxxx2X//3f/80ZZ5wx21Vc68viiy+eJJk06etRbZ06dUpVVdUs7UaPHp0kpfntOnXqlMmTJ2fChAkztfvqq6/yxRdflOa8AwAAAIAFaZ5H2P32t79N69atc+ONN+bGG29MkyZNZjv3XFlZWZ599tkfVOTs9OvXL+Xl5bnmmmtm2v7BBx8kSTp37pzk61VeH3zwwXz88celbUny5ptvJklWX331Urvk69Vg11tvvW9tBwAAAAAL0jyPsBsxYkSqq6uz5JJLZskll0y7du3SsmXLWf6b3YIP80ObNm3y1FNP5eWXXy5tq6mpyWWXXZaKiopsvfXWSZItttgiZWVlueGGG0rtqqurc+ONN6Zjx47p0aNHkqRPnz5p1qxZhg4dOtNxhg4dmqZNm2azzTZbIOcBAAAAADOa5xF2Dz/88Pys43s79thj8+STT+bggw/OPvvsk3bt2uWf//xnnn/++Rx99NGlBTGWX3757L777rnhhhsyceLEdO/ePcOGDcvLL7+cCy+8MI0aNUqStG7dOkcccUTOP//89O/fP3369MkTTzyR++67L8cee2zatm1bn6cLAAAAQAMxz4FdfVt66aVz00035aKLLsrQoUMzderUrLDCCjnnnHOy4447ztT2lFNOyRJLLJHbb7899957b7p06ZJLLrmktIpsnUMOOaQ0yu6xxx7L0ksvndNOOy177rnnj3hmAAAAADRkZbW1tbXz8sCHHnporttuuumm83KIRUJ1dU3GjJlY32UslCory9O2bYv0GTw4r40cWd/lLDDdOnXKv/r3z9ixE60SCwAAAIuwdu1apKJizjPUzfMIu/79+6esrGyu2r711lvzehgAAAAAaFDme2A3efLkfPTRR3n00UezxhprZL/99vtBBQIAAABAQzLPgd2RRx75nfv//e9/Z6+99sqXX345r4cAAAAAgAZnzjfNzqNVVlklW265Za655poFdQgAAAAAWOQssMAuSdq2bZv//Oc/C/IQAAAAALBIWWCB3ZgxY/LPf/4z7du3X1CHAAAAAIBFzjzPYTdgwIDZbq+pqcnkyZPz2muvZdKkSenfv/88FwcAAAAADc08B3YPPvjgd+5v3bp1+vXrl8MPP3xeDwEAAAAADc48B3YPPfTQbLeXlZWlUaNGWXzxxVNevkCnyAMAAACARc48B3ZLLbXU/KwDAAAAAMgPCOzqvPDCC7n99tvzzjvvZPLkyWnTpk1+9rOfZfvtt0+PHj3mR40AAAAA0GD8oMDu/PPPz5/+9KfU1tYmSZo1a5YPP/wwL7/8cm699dYccsghGThw4HwpFAAAAAAagnmeZG7YsGG5+uqrs8IKK+TKK6/MCy+8kJdffjmvvvpqrrnmmnTt2jVXXXXVHBenAAAAAAD+zzwHdjfccEPat2+fG264Ib17907Lli2TJI0bN84GG2yQa665JksssUSGDh0634oFAAAAgEXdPAd277zzTjbeeOO0bdt2tvvbtWuXjTfeOG+99dY8FwcAAAAADc08B3Zza9q0aQv6EAAAAACwyJjnwK5r16555JFH8sUXX8x2/5gxY/Lwww+na9eu83oIAAAAAGhw5jmw23fffVNVVZUDDzwwzz33XKZPn54kmTBhQh599NH069cvn3/+efbee+/5ViwAAAAALOoq5/WBW2+9dV5//fVce+212W+//VJeXp7GjRtnypQpSZLa2trsv//+2XbbbedbsQAAAACwqJvnwC5JTjjhhGy66aa544478vbbb2fixIlp0aJFVlpppey8887p0aPH/KoTAAAAABqEHxTYJUmPHj0EcwAAAAAwn8zTHHYffPBBxo4dO9t9l1xySV588cUfVBQAAAAANFTfK7CbOnVqBg4cmG233TaPPvroLPurqqpy+eWXZ++9907//v0zYcKE+VYoAAAAADQEcx3YVVdX56CDDso//vGP/OQnP0nbtm1nadOsWbMce+yxWWaZZfLQQw/lsMMOS21t7XwtGAAAAAAWZXMd2P3lL3/Jc889l+233z73339/evfuPUubli1b5qCDDspdd92VTTfdNC+++GJuu+22+VowAAAAACzK5jqwu/vuu9OpU6eceeaZqaz87rUqmjZtmnPOOSdt27bNnXfe+UNrBAAAAIAGY64Du3fffTcbbbRRGjVqNFftW7ZsmQ033DDvvPPOPBcHAAAAAA3N95rDbrHFFvteT96xY8dMnz79excFAAAAAA3VXAd2Sy65ZD766KPv9eQfffRROnbs+L2LAgAAAICGaq4Du3XWWSePPfZYqqqq5qp9VVVV/vWvf6Vr167zXBwAAAAANDRzHdjtsccemTp1ao466qhMmDDhO9tOmDAhRx55ZKZNm5Y99tjjBxcJAAAAAA3FXAd2q6yySg477LC8/PLL2XLLLXPFFVfktddey5dffpmampqMHTs2r776agYPHpzNN988r7zySnbeeedssMEGC7J+AAAAAFikVH6fxkcddVQaNWqUyy+/PJdcckkuueSSWdrU1tamUaNGOfjggzNw4MD5VigAAAAANATfK7ArKyvLEUccka233jp/+9vf8vjjj2fUqFEZP3582rRpk86dO6dXr17Zdttt07lz5wVVMwAAAAAssr5XYFdn2WWXzcCBA42gAwAAAID5bK7nsAMAAAAAFjyBHQAAAAAUiMAOAAAAAApEYAcAAAAABSKwAwAAAIACEdgBAAAAQIEI7AAAAACgQAR2AAAAAFAgAjsAAAAAKBCBHQAAAAAUiMAOAAAAAApEYAcAAAAABSKwAwAAAIACEdgBAAAAQIEI7AAAAACgQAR2AAAAAFAgAjsAAAAAKBCBHQAAAAAUiMAOAAAAAApEYAcAAAAABSKwAwAAAIACEdgBAAAAQIEI7AAAAACgQAR2AAAAAFAgAjsAAAAAKBCBHQAAAAAUiMAOAAAAAApEYAcAAAAABSKwAwAAAIACEdgBAAAAQIEI7AAAAACgQAR2AAAAAFAgAjsAAAAAKBCBHQAAAAAUiMAOAAAAAApEYAcAAAAABSKwAwAAAIACEdgBAAAAQIEI7AAAAACgQAR2AAAAAFAgAjsAAAAAKBCBHQAAAAAUiMAOAAAAAApEYAcAAAAABSKwAwAAAIACEdgBAAAAQIEI7AAAAACgQCrru4CGrry8LOXlZfVdxgJXU1Obmpra+i4DAAAAoPAEdvWovLwsrds0T2XFoj/QcXp1TcZ9MUloBwAAADAHArt6VF5elsqK8hxyyy0ZXlVV3+UsMCu2b5+rdtst5eVlAjsAAACAORDYFcDwqqq8NnJkfZcBAAAAQAEs+vdiAgAAAMBCRGAHAAAAAAUisAMAAACAAhHYAQAAAECBCOwAAAAAoEAEdgAAAABQIIUP7K666qpsuOGGs903ZcqUnHfeedl4442zxhprZPfdd8/TTz89S7vq6upcffXV2XzzzdOtW7dsv/32GTZs2Gyf87bbbsu2226bNdZYI1tssUVuvPHG+Xo+AAAAAPBdCh3YPfroo7nkkku+df8xxxyTa665JptuumlOOOGETJs2LQcddFBeeOGFmdqdc845Oe+887LWWmvl5JNPTrt27TJw4MDcc889M7W7/vrr8+tf/zqdO3fOiSeemJVWWimnn356rrzyygVyfgAAAADwTYUM7Gpra/PnP/85/fv3z7Rp02bb5umnn86DDz6Y448/PoMGDcpee+2VP//5z1lyySVz1llnldp9+OGHGTp0aPbZZ5+cffbZ2WOPPTJkyJCsueaaOfvsszN16tQkyfjx43PRRRdl0003zeWXX54999wzF198cbbeeutcfvnlGTNmzI9y7gAAAAA0bIUM7Hbffff87ne/y7rrrptVV111tm3uvvvuNGrUKLvttltpW/PmzbPrrrvmzTffzIcffpgkuffee1NTU5O+ffuW2lVUVKRv376pqqrK888/nyR5+OGHM2nSpOy1114pKysrtd1nn30yZcqUPPjggwvgTAEAAABgZoUM7EaOHJnTTz89f/rTn9KiRYvZtnnjjTfSpUuXNG/efKbtdQHfG2+8Ufp/y5Yt06VLlzm2S5LVVlvtO9sBAAAAwIJUWd8FzM7DDz+cxo0bf2ebUaNGpVu3brNs79ChQ5KvQ7+6dh07dpxju9GjR6dp06Zp06bNTO2aNGmSNm3alNoBAAAAwIJUyMBuTmFdkkycODHNmjWbZXvTpk2TJJMnTy61m90ovdm1q9v2TU2aNCm1mxeVlbMfyFhRUcgBjgvM9z1f/QMAAAA0RIUM7OaHGeehm/HP39autrZ2rtp9X+XlZWnbdva39TY0rVrNGrDyf/QPAAAAkCzEgV3z5s0zZcqUWbbXbWvZsuV8aZckX331Vand91VTU5vx4yfNdl9FRXmDCmnGj5+c6uqauW6vfwAAAIBFSatWzebqDruFNrDr1KlTqqqqZtk+evToJCnNW9epU6fSSrBzajd58uRMmDBhpnDuq6++yhdffFGa825eTJ8uhEmS6uoaffEd9A8AAACQFHSV2Lmx6qqr5r333ptlVNybb76ZJFl99dVL7caNG5ePP/54ju2SWVeD/WY7AAAAAFiQFtrAbsstt8zUqVPzl7/8pbRt0qRJue2229KtW7css8wySZItttgiZWVlueGGG0rtqqurc+ONN6Zjx47p0aNHkqRPnz5p1qxZhg4dOtNxhg4dmqZNm2azzTb7Ec4KAAAAgIZuob0ltlevXunVq1f+8Ic/5NNPP02XLl1yyy235LPPPsvZZ59darf88stn9913zw033JCJEyeme/fuGTZsWF5++eVceOGFadSoUZKkdevWOeKII3L++eenf//+6dOnT5544oncd999OfbYY9O2bdv6OlUAAAAAGpCFNrBLkosvvjgXXnhh7r777kyePDldu3bNkCFDSqPm6pxyyilZYoklcvvtt+fee+9Nly5dcskll2SLLbaYqd0hhxxSGmX32GOPZemll85pp52WPffc88c8LQAAAAAasLLa2tra+i5iUVZdXZMxYybOdl9lZXnatm2RPoMH57WRI3/kyn483Tp1yr/698/YsRO/16IK+gcAAABYlLRr12KuVoldaOewAwAAAIBFkcAOAAAAAApEYAcAAAAABSKwAwAAAIACEdgBAAAAQIEI7AAAAACgQAR2AAAAAFAgAjsAAAAAKBCBHQAAAAAUiMAOAAAAAApEYAcAAAAABSKwAwAAAIACEdgBAAAAQIEI7AAAAACgQAR2AAAAAFAgAjsAAAAAKBCBHQAAAAAUiMAOAAAAAApEYAcAAAAABSKwAwAAAIACEdgBAAAAQIEI7AAAAACgQAR2AAAAAFAgAjsAAAAAKBCBHQAAAAAUiMAOAAAAAApEYAcAAAAABSKwAwAAAIACEdgBAAAAQIEI7AAAAACgQAR2AAAAAFAgAjsAAAAAKBCBHQAAAAAUiMAOAAAAAApEYAcAAAAABSKwAwAAAIACEdgBAAAAQIEI7AAAAACgQAR2AAAAAFAgAjsAAAAAKBCBHQAAAAAUiMAOAAAAAApEYAcAAAAABSKwAwAAAIACEdgBAAAAQIEI7AAAAACgQAR2AAAAAFAgAjsAAAAAKBCBHQAAAAAUiMAOAAAAAApEYAcAAAAABSKwAwAAAIACEdgBAAAAQIEI7AAAAACgQAR2AAAAAFAgAjsAAAAAKBCBHQAAAAAUiMAOAAAAAApEYAcAAAAABSKwAwAAAIACEdgBAAAAQIEI7AAAAACgQAR2AAAAAFAgAjsAAAAAKBCBHQAAAAAUiMAOAAAAAApEYAcAAAAABSKwAwAAAIACEdgBAAAAQIEI7AAAAACgQAR2AAAAAFAgAjsAAAAAKBCBHQAAAAAUiMAOAAAAAAqksr4LAKB+lZeXpby8rL7LWOBqampTU1Nb32UAAADMkcAOoAErLy9L6zbNU1mx6A+4nl5dk3FfTBLaAQAAhSewA2jAysvLUllRnkNuuSXDq6rqu5wFZsX27XPVbrulvLxMYAcAABSewA6ADK+qymsjR9Z3GQAAAMSiEwAAAABQKAI7AAAAACgQgR0AAAAAFIjADgAAAAAKRGAHAAAAAAUisAMAAACAAhHYAQAAAECBCOwAAAAAoEAEdgAAAABQIAI7AAAAACgQgR0AAAAAFIjADgAAAAAKRGAHAAAAAAUisAMAAACAAhHYAQAAAECBVNZ3AT/UHnvskZdffnmW7SuttFLuuuuuJMnYsWNz4YUX5uGHH87EiROzxhpr5Pjjj88qq6wy02OmTJmSyy67LPfee2/GjBmTlVZaKUcffXTWX3/9H+VcAAAAAGChD+yGDx+ePn36ZOutt55pe5s2bZIkU6dOzaGHHpp33nkn/fr1yxJLLJGhQ4dm7733zu23354uXbqUHnPMMcfkkUceyV577ZXlllsut912Ww466KBcf/316dGjx495WgAAAAA0UAt1YPfJJ59k4sSJ6dOnT3bYYYfZtrnrrrvy6quv5rLLLsvPf/7zJMmWW26ZrbbaKhdeeGEuueSSJMnTTz+dBx98MCeddFL69euXJNlxxx2z/fbb56yzzsodd9zxo5wTAAAAAA3bQj2H3fDhw5Mkyy+//Le2ueeee9KhQ4dSWJck7du3z1ZbbVW6RTZJ7r777jRq1Ci77bZbqV3z5s2z66675s0338yHH364YE4CAAAAAGawUAd27777bpJkhRVWSJJS+DajN998M6uuuuos21ddddVMmzatFPq98cYb6dKlS5o3bz5Lu7r9AAAAALCgLdS3xL7zzjtp0qRJLr744txzzz2ZMGFCOnTokIMPPjj77rtvJk6cmC+//DI/+clPZnlshw4dkiSffvpp1lxzzYwaNSrdunX71nYjR46c5zorK2efi1ZULNR56ff2fc9X/8CC19Cuu4Z2vgAAwMJpoQ7s3n333Xz11VcZNWpUzjrrrEyePDm33nprzjzzzHzxxRfZY489kiTNmjWb5bFNmzZNkkyaNCnJ16Pzvqvd5MmT56nG8vKytG3bYp4eu6hp1WrW/uX/6B9Y8LzOAACAhcFCHdjtvvvuqa6uzr777lvatv3222fPPffMVVddld13332Oz1FWVjZXx5rbdt9UU1Ob8eMnzXZfRUV5g/rwOH785FRX18x1e/0DC57XGQAAwI+nVatmc3Xnz0Id2PXt23eWbeXl5dl9991z0kkn5amnnkqSTJkyZZZ2ddtatmyZ5OsFJuam3byYPt2HwySprq7RF99B/8CC53UGAAAsDBbJyXwWX3zxJElNTU1atWqVqqqqWdqMHj06SdKxY8ckSadOneaqHQAAAAAsSAttYDdy5Mhss802ufjii2fZ98EHHyRJOnfunFVXXTVvvvnmLG3efPPNVFZWZuWVV07y9Wqw77333iyj7Ooeu/rqq8/vUwAAAACAWSy0gd2SSy6ZcePG5dZbb824ceNK28eNG5frrrsuSy21VNZaa61sueWWGTlyZB588MFSm6qqqvzjH//Iz3/+8zRp0iRJsuWWW2bq1Kn5y1/+Umo3adKk3HbbbenWrVuWWWaZH+/kAAAAAGiwFto57MrKyvKb3/wmAwYMyG677ZY999wzU6dOzV//+td8/vnnufrqq1NZWZlddtklN910U4499tgccMABadeuXW644YaUlZXlqKOOKj1fr1690qtXr/zhD3/Ip59+mi5duuSWW27JZ599lrPPPrsezxQAAACAhmShDeyS5Oc//3muuOKKXHXVVbngggtSWVmZNddcMxdccEHWWGONJEmjRo1y7bXX5txzz82f//znVFdXZ4011sjFF1+c5ZZbbqbnu/jii3PhhRfm7rvvzuTJk9O1a9cMGTIkPXr0qI/TAwAAAKABWqgDuyTZZJNNsskmm3xnm8UXXzznnHPOHJ+rRYsWGTRoUAYNGjS/ygMAAACA72WhncMOAAAAABZFAjsAAAAAKBCBHQAAAAAUiMAOAAAAAApEYAcAAAAABSKwAwAAAIACEdgBAAAAQIFU1ncBAFB05eVlKS8vq+8yFriamtrU1NTWdxkAANDgCewA4DuUl5eldZvmqaxY9AelT6+uybgvJgntAACgngnsAOA7lJeXpbKiPIfcckuGV1XVdzkLzIrt2+eq3XZLeXmZwA4AAOqZwA4A5sLwqqq8NnJkfZcBAAA0AIv+/T0AAAAAsBAR2AEAAABAgQjsAAAAAKBABHYAAAAAUCACOwAAAAAoEIEdAAAAABSIwA4AAAAACkRgBwAAAAAFIrADAAAAgAIR2AEAAABAgQjsAAAAAKBABHYAAAAAUCACOwAAAAAoEIEdAAAAABSIwA4AAAAACkRgBwAAAAAFIrADAAAAgAIR2AEAAABAgQjsAAAAAKBABHYAAAAAUCACOwAAAAAoEIEdAAAAABSIwA4AAAAACkRgBwAAAAAFIrADAAAAgAIR2AEAAABAgQjsAAAAAKBABHYAAAAAUCACOwAAAAAoEIEdAAAAABSIwA4AAAAACkRgBwAAAAAFIrADAAAAgAIR2AEAAABAgQjsAAAAAKBABHYAAAAAUCACOwAAAAAoEIEdAAAAABSIwA4AAAAACkRgBwAAAAAFIrADAAAAgAIR2AEAAABAgQjsAAAAAKBABHYAAAAAUCCV9V0AAADAD1VeXpby8rL6LmOBq6mpTU1NbX2XAcACJrADAAAWauXlZWndpnkqKxb9G4imV9dk3BeThHYAiziBHQAAsFArLy9LZUV5DrnllgyvqqrvchaYFdu3z1W77Zby8jKBHcAiTmAHAAAsEoZXVeW1kSPruwwA+MEW/THjAAAAALAQEdgBAAAAQIEI7AAAAACgQAR2AAAAAFAgAjsAAAAAKBCBHQAAAAAUiMAOAAAAAApEYAcAAAAABVJZ3wUALGjl5WUpLy+r7zIWuJqa2tTU1NZ3GQAAAPxAAjtgkVZeXpbWbZqnsmLRH1A8vbom476YJLQDAABYyAnsgEVaeXlZKivKc8gtt2R4VVV9l7PArNi+fa7abbeUl5cJ7AAAABZyAjugQRheVZXXRo6s7zIAAABgjhb9e8QAAAAAYCEisAMAAACAAhHYAQAAAECBCOwAAAAAoEAEdgAAAABQIFaJhYVceXlZysvL6ruMBa6mpjY1NbX1XQYAAAAscAI7WIiVl5eldZvmqaxY9AfLTq+uybgvJgntAAAAWOQJ7GAhVl5elsqK8hxyyy0ZXlVV3+UsMCu2b5+rdtst5eVlAjsAAAAWeQI7WAQMr6rKayNH1ncZAAAAwHwgsAMAWMDMNwoAwPchsAMAWIDMNwoAwPclsAMAWIDMNwoAwPclsAMA+BGYbxQAgLm16N+bAQAAAAALEYEdAAAAABSIW2IBAACAObLqOfx4BHYAALAQ8EEZqE9WPYcfl8AOAAAKzgdloL5Z9Rx+XAI7AAAoOB+UmR+M0mR+sOo5/DgEdgAAsJDwQZl5ZZQmwMJFYAcA/GBGbQAUm1Gac8fvM6AoBHbfMHLkyPzhD3/I008/nWnTpmW99dbLiSeemM6dO9d3aQBQSEZtACw8jNL8dn6fAUUisJvBF198kX333TcTJkzIfvvtl8aNG+eaa65J3759c+edd6Zdu3b1XSIAFI5RGwAsCvw+Y34wSpP5RWA3g+uuuy4jRozIbbfdltVWWy1J0qtXr+y44465+uqrc8IJJ9RzhQBQXEZtALAo8PuMeWWUJvOTwG4G99xzT7p3714K65JkxRVXzHrrrZd77rlHYAcAAADMllGazE8Cu/9v3Lhx+fjjj9OnT59Z9q266qp58sknM3r06HTo0OHHLw4AYBHnFiIAFhVGaTI/COz+v1GjRiVJOnbsOMu+upDu008/FdgBAMxnbiECgIahoXxBl/zwL+nKamtrvVtI8vLLL2ePPfbIKaeckr333numfbfeemsGDRqU6667Luuvv/73et7a2m//ByorS8rLy1M1YUKmVVfPc+1F16iiIu1btkxNTU2+z9Wmf+ZMH82ZPvpu+mfO9NGc6aPvpn/mrK6Pvpg8OdNrahZMgQVQWV6eNs2aeZ19B6+z7+Zn9ZzpoznzOvturqE5+yF9VF5elrKyhhHYfVseNLd9YITd/1eXW35Xp83LRVVWVpaKiu9+XPuWLb/38y6Mysvn7Vtz/TNn+mjO9NF30z9zpo/mTB99N/0zZ22aNZuPlRSX19mceZ19N9fQnOmjOfM6+26uoTn7IX3UEMxNHvRd9O7/17x58yTJ5MmTZ9k3ZcqUJEnLBvKiAwAAAKD+COz+v6WWWipJUjWblVxGjx6dZPbz2wEAAADA/CSw+/8WW2yxLLPMMnnzzTdn2ffmm2/mJz/5Sdq3b18PlQEAAADQkAjsZrDlllvmxRdfnCm0Gz58eJ555plsu+229VgZAAAAAA2FVWJn8MUXX2S77bbLtGnTcuCBB6a8vDzXXnttGjVqlNtvvz3t2rWr7xIBAAAAWMQJ7L7h448/zu9///s8/fTTady4cXr27Jnjjz8+nTt3ru/SAAAAAGgABHYAAAAAUCDmsAMAAACAAhHYAQAAAECBCOwAAAAAoEAEdgAAAABQIAI7AAAAACgQgR0AAAAAFIjADmA+qK2tre8SWMi5hpgfXEdzNmbMmPouAQBgjgR2APNBWVlZfZfAQq6srCw1NTX1XUZhnXLKKXnrrbfqu4zC87Poux111FG55JJL6rsMAIA5qqzvAljwpk+fnspK/9Sz88EHH2TMmDHp3LlzmjZtmtatW9d3SSxk7rvvvnz00UeZNm1aevbsmXXWWae+Syqc999/P6NGjcpSSy2VxRZbLO3atavvkgpl0KBB+elPf5qDDz445eXlqampSXm579Nm1K9fvwwfPjzbbbddfZdSWMOGDcuIESNSWVmZtddeO2ussUZ9l1Q4hx12WP71r39liSWWyJFHHpnFF1+8vksqlNdeey2jRo1Kx44d06FDh/zkJz+p75IKZ8SIEfnss8+y+OKLp3nz5unYsWN9l7RQqa2t9aUCLGBeZ99uYXyPLcVZxJ1wwgmZPHlyzj777DRv3ry+yymUgQMH5tlnn82YMWPStGnTrLbaajniiCOywQYb1HdpLCQOP/zwPPfcc5k+fXqmTp2a2traHHbYYTn88MPTpEmT+i6vEI455pg899xzqaqqSmVlZTbaaKMMHDgwXbt2re/SCmHUqFG57bbbstxyy6VZs2bZe++9hXbfsP/+++fdd9/N7373u3Tv3r2+yymkGX8WffXVV1l11VVz/vnnZ9lll63v0gqjX79++eijj7L55pvn6aefztSpU+u7pEI56qij8tRTT2XChAlJklVWWSWnnnqq19wMTjrppLz44ov56KOPUllZmQ4dOuTII4/MNttsk8aNG9d3eYU0ZsyYTJkyJYsttlgWW2wxIcI3vP3221lppZXqu4zCe/rppzNmzJhUV1dnww03TNu2bb1HmsHnn3+eL7/8Mi1atEj79u1TVlYmtPuGM844I7vuumtWWmmlhe49tsBuEde2bdvcddddWWqppXLUUUelWbNm9V1SIZx88sl56aWXcsABB6Rbt2556qmnMmzYsBxwwAE58cQTs+eeewpckvz6179Os2bNMmjQoPoupXCOO+64vP766znuuOOy+eab54MPPshtt92WK6+8Ml26dMkOO+xQ3yXWu+OPPz4vvfRS9tlnn6yxxhp54IEH8uc//zlNmjTJ73//+zRr1qxBv5morq7OYostlqWXXjoffPBBbrjhhpSVlaVv375Cu/9v//33z3vvvZff/va36dWrlw/Fs3HOOefkjTfeyMknn5xNN900b731VmpqatKpU6f6Lq0w+vXrl3feeSdnn312ampq8uCDD+bJJ5/Mrrvu6kNNvv5i5aWXXkr//v2z9tpr5+GHH84111yT3//+97niiiuMis7XX/I+//zz2X///dOrV6+88sorue+++3LSSSflnXfeySGHHKKfvuHkk0/Oa6+9lg8//DA//elP07t37xx00EFp27Ztg3/NJck111yTa6+9NhdffHHWWmut+i6nsI4++ug899xzpblHV1xxxey3337Zfvvt06hRo3qurv6dcsopeeWVV/Luu++mc+fO2W677XLUUUd5jc3gwQcfzJ///Oc8++yzueiii7L88ssvVO+xBXaLuA4dOiRJrr322kyYMCG//vWv07Rp03quqn6NGjUqzzzzTLbbbrvsu+++ady4cXr27JkNNtggQ4cOzTnnnJOxY8fmsMMOa9AB59SpU1NVVZXHHnssSyyxRA477LD6Lqkw3nvvvTz55JPZbbfdst1226VFixZp165dGjVqlAceeCCXX355Nthgg7Rv376+S603//u//5unnnoqe+21V/r165fGjRtn3XXXzZdffplHHnnEh+QkFRUVad68edZZZ520bNkyn376aS666KKUl5dnzz33bPCh3cknn5ynn34655xzTjbbbLOZ9o0aNap0DTXkW9KmTp2al156Keuuu2622267NG7cOOuvv36Sr/to6tSpady4cYPuowMPPDDvvvtuzjjjjPTu3TtjxoxJZWVl3n777STm/Hv//ffz1FNP5Re/+EX69u2bxo0bp1u3bpk+fXqGDBmSiRMnNvgg6u23386jjz6a3XffPXvttVeaNWuWFVdcMWuttVauvPLKXHfddZk+fXoOPfTQBv17f0ZHH310XnjhhWy55ZbZaaed8uyzz+aGG27Iiy++mEMOOST/8z//0+DDloqKilRVVeV3v/tdTj75ZFOqzMZRRx2VF154Ifvvv39WX331/Pe//83FF1+cyy+/PF26dMlaa63VoN9P/vKXv8yLL75Yep3dd999ufzyy9OkSZMceuih9V1eYXTr1i1LLrlk3n333Rx11FG58MILs+KKKy4077GLXyHzpG6VuM8++yxNmjTJtttum1tvvTVnnnlmpkyZUs/V1a+xY8dm5MiRWW211dK4ceN89dVXSZKePXvm6KOPzo477pgrr7wyQ4YMabATwNfU1KRx48bp0qVLkuTSSy/NxRdfXM9VFceoUaMyZsyY9OrVKy1atMi0adOSJGussUY22mijjB8/PtOnT6/nKuvXf//73/z3v//N2muvPdPrbMUVV8z06dPz/PPP5+abb86zzz7bYPuq7uf0Yostlvbt2+f2229PkyZNctFFF+Xmm28uvZFoqD+zmzdvnoqKikyYMKH0GkuS0047Lf369csOO+yQX/ziF/nTn/6Uzz//vB4rrR+1tbX54osv8sEHH6R9+/YzjT486aSTsueee2bnnXfOLrvskiFDhjTIlVEPO+ywPPfccznjjDPSq1evJEnr1q2zzjrr5JFHHsknn3xSzxXWv//+978ZO3ZsVlxxxTRu3DiTJk1Kkqy11lpZYoklSl9y1gWcDdHo0aMzadKkrLPOOmnWrFnpduoVVlghu+66a5o0aZI///nPufrqqzN58uR6rrb+vfLKK3nppZdy+OGH59hjj82BBx6Ys88+O+edd15GjRqVM844I3fffXeDvS297rPFkksumST5+OOPc8YZZ+SFF16oz7IK59FHH82zzz6b/v37Z5999sl6662XbbfdNr/5zW8ycuTI3HXXXUka7pcuTzzxRF588cX88pe/zLHHHpsDDjggZ511Vn7605/mX//6V4N9fc1O3Vz+7du3z4QJEzJw4MC89957pS/Gi05gt4iq++H13//+N8sss0z69++fvfbaS2iXZJlllkmHDh3y4IMPJkmaNGmS6urqJMnyyy+fQw89NDvuuGMuu+yy3H777fVZar2pu34+++yzNGvWLKusskquuOKKXHbZZfVcWTF07tw5jRs3Ll1DjRo1KgUKHTp0yNixY/PRRx/VZ4n1bskll0zjxo3zwAMPJEnpFvP3338/kyZNyqBBg/Lb3/42++23X373u9+lqqqqPsutF3Wvs4033jivv/562rdvnyFDhqSioiIXXXRR/v73v+eNN97IxRdfnE8//bSeq/3x1AWZgwYNynrrrZcrr7yy9Ho66KCDctddd2X55ZfPVlttlSWWWCIXXHBBzj333HzxxRf1WPWPr6ysLB06dEiXLl3y2muvlbYfccQReeCBB7Leeutll112SadOnXL++efn3HPPzdixY+ux4h/ffvvtl8suuywbbrhhKdCsqKhI796988knn+Q///lPkiwUb9gXlM6dO2exxRbLvffemySl+Y7//e9/p6qqKv3790+/fv2y44475owzzsjo0aPrs9x60apVqyTJSy+9lCRp3Lhx6X3juuuum5VWWimrr756hg4dmr/85S/1VmdRjBs3LqNHj84yyyyTpk2bpqamJu3atcuWW26Zyy67LBUVFbnwwgtz3333Ndgv7JKvv/xt3bp1+vTpk/fffz+nn3660G4Gn332WcaNG5fu3bunadOmpfcGK620Ujp37pxHH300EyZMaLA/v6uqqjJmzJh07dq19DpbYYUVsvrqq+fzzz/PiBEj8vTTT+fzzz9v0K+z2tratGvXLuutt1423XTT7L333vnoo4/yy1/+Mu+++25phF3d9VVEboldhP33v//Nhx9+mNVWWy1dunTJvvvumyS56aabkqTB3h5bXl6eddZZJ48++miGDRuWrbfeOhUVFamurk5FRUWWXXbZ7L///qmqqsoZZ5xReiPWkNQFCZ9//nk22mijHHrooTnjjDNKgd2AAQPqs7x616pVq7Rt2zYvvvhiaUW9ioqK0r7k//qwoQ7VX2yxxbL++utn6tSpmTZtWho1apRnnnkmd9xxR/r27Zs+ffqksrIyDzzwQG655Za0adMmAwcOrO+y60Xbtm3z5Zdf5tVXX03Pnj1z/fXXZ//998+ZZ56ZiRMnpnfv3ll88cUXmqH7P1RZWVnpXE855ZQcdNBBGTRoUPr27ZtRo0bl8ssvz1prrZUmTZpk5MiRueWWW3LllVdm5ZVXTr9+/eq7/B9NbW1tamtrs8EGG+Taa6/NnXfemS5duuTDDz/M+eefnw022CCNGjUq9dFVV12Vn/3sZznwwAPru/Qfzfrrrz/Tz+C6P//85z/PkCFDcv3112fttddu0HPWtmrVKhtvvHH+/ve/Z7/99ssGG2yQUaNG5ZZbbslOO+2UzTbbLOXl5XnooYfyl7/8JZWVlTnxxBPru+wf1dJLL50lllgiDzzwQHr37p0ePXqkoqIiU6dOzeTJkzN16tQcfPDBefHFF3P++edn7bXXTrdu3eq77HrTtGnTVFRUZNy4cUlmXpVxtdVWy+DBg3PEEUdk8ODB+clPfpKePXvWZ7k/mrqfP3V9MXz48LRo0SLnnXdeunfvnnPOOSenn356Tj311PTo0aOeq61/zZo1S3l5+UyjVmtqarLEEktk1VVXzQMPPJApU6akZcuW9Vhl/WncuHFqamoyceLE0rZp06alqqoq48aNy5577plx48Zl2WWXza677pq99967QX7ur/v936pVqzz//PM57bTTMm3atFx99dU5+uij86c//Snl5eW56667SlP4FM2i/86/AVtiiSWyww47ZPPNN0+SUhDV0EfaNW3aNEcccUSqq6tz7bXXlr4xrQvtkqRr167p27dvmjRpknvuuSdJsZP3BWHcuHF54YUXsswyy2S11VbLSSedlO7du+eyyy5r8CPt2rRpk2uuuSann356aW6obwYpdfMf1v2iGDt2bIO6VaZ169Y566yzctJJJ5XmqenRo0dOPPHEHHDAAenVq1fWX3/9DBgwIL179861116bESNG1HPVP77a2toss8wyWW655fLee+8lSX72s5/llFNOycSJE9OoUaOsscYaady48UIzdH9+qHs9Lb300jn00EPz/vvv58wzz8xyyy1XCuuSpFOnTtljjz2y5ppr5pprrmlQo+zqPvjtsssuad68eW6//fY88sgjGT9+fLp27Vp63XXq1Cl77rln1l133Vx11VUNboTUjF+Y1P35Jz/5SdZaa608++yzpdGJDeW19U0tW7bMMccck/333z9ffvll7rrrrvzlL3/JJptskmOPPTabbrppNt544/zqV7/KFltskeuvvz7vvvtufZf9o1piiSVy6qmnZuTIkRk8eHD++c9/Jvn6i/E//vGPGTFiRNZZZ53suuuuadeuXf71r38laVjvG2c8127dumX11VfPBRdckE8//TSVlZUzvb66du2a8847LxMnTsyVV15ZH+XWi7KystLnjOnTp6eqqirNmjVLbW1t9t577wwcODD/+7//26BH2s14Ha288spp1KhRLr/88kydOnWmsLNulOvCMDpqfprxPFdaaaV07do1w4YNS/L1+6annnoqL7zwQjbeeOMMGDAgv//975MkF198cWkU9aLum9dC3c+eNddcM2PGjMnkyZNzxBFH5IADDsjIkSOzzz77ZPPNN89nn31W2FxEYLeIqrtY99tvv2y88cal7Z07dxba5etbX88999y88847GTx4cOkNe0VFRWnY8CabbJKePXvmySefTE1NTYMbJdW6detce+21WWWVVZJ8PT/boEGDhHb/3/LLL5+VVlqp9Pe6N2ETJkxIkpnm3Hr33Xdzwgkn5LrrrmtQHwoXX3zxNGvWLDU1Namurk5lZWX69euXpZZaKklKt8nUjcSr67uGpKysLM2bN8/iiy+ep556Kkny6quv5tRTT03Pnj3TrFmzXHvttbnllltSW1vbIEbYzaiysjI///nPs/7662fs2LFZZZVVZhkNVTdCY/z48aW5EhuSzp0759xzz81rr72WG264Ie3atctPfvKTJCn9PuvYsWM22mijfPnll/nyyy/rs9x6V/f7/Fe/+lWaNWuWm2++OcnXH3Yayoe+b+rYsWOOPfbY3HHHHTn//PPTunXrrLfeeqWRvXU/qzfaaKPU1tbmv//9b32X/KPbdNNNc8opp+Tll1/O0UcfnV69emW77bbLjTfemEGDBqV9+/ZZeeWVs8oqq+S5555L0rDm1poxjGrWrFm23nrr/Pe//80555yTMWPGzPKF0+qrr54jjzwyTz75ZP7617/WV9k/il//+tc544wzkvzf54zKysr85je/ycknn1y6Tg444IAGH9rNeB397Gc/y3HHHZejjz56llFPFRUVpVHmdY9Lki+//HKm99+Lmhn7Z/nll8+pp56ak046qbS/trY2Rx55ZI477rjss88+2WmnnfKXv/wlbdu2LQV7i7oZ+yj5vy+AV1111YwdOzZPP/10kuTII4/M9ttvn5EjR6aysjKbbbZZWrVqVcj3AQ3rnX8D8l1vEr4Z2v3+979vkKHdpptumkGDBuW5557LRRddVHqDVVlZWXqxtmjRokG/iV9//fWzzTbbpLa2NjU1NVlttdVmCu0uvfTS+i6xcOpuAakbdv7ee+/lggsuyOOPP54+ffo0uMAl+fqX5YwjWGfcniRjxozJ4osvXrqduCGZcU6WqVOn5u23385BBx2UtdZaK3/84x9z4403pkmTJjn11FNzxx131HO19aNNmzY59thjc+ihh2attdaabZtJkyaldevWDfbWxl69euW3v/1tkq9vs7rqqquS/N9Ey8nX4V2bNm0KebvHj6nu50779u2z44475v7778+tt96a5Ov3Tg31931dv4waNSpjx47N+PHjS9vr9n3++edp3bp1g1w1tqKiIrvttltuvfXW9O3bNz179szmm2+em266Kdttt12pXVlZWWmKjIbgm2FUXViy7777Zosttsh9992XSy+9NGPHjp0ptKusrMz//M//ZMkll8xbb71Vb/UvaFOnTk1VVVX+/Oc/549//GOSr8+9uro6Sy65ZDbccMMk//flSkMN7b55HdUtmLD33nvPdHt53fvIusVxZpybre799t/+9rcfq+wfzbe9ztZee+00b9681C99+vRJ3759s/jiiydJpkyZkjZt2qRPnz558803M2LEiEX2d9w3+2jGzxzV1dVZbLHF0qZNm9IiZcOHD88//vGPLLvssqmurs6ZZ56Z999/vzQtS5E0vE+ODVzdxVsX2u29997561//mvPPP7+eK/vxlZWVZZdddsmpp56aF154Ib/73e9metP+7rvv5j//+U+6dOkyS9DQ0Mw4DH3G0G7w4MEZPHhwPVdXDHVv0CsrK9O8efM0bdo0H3/8cf7whz/kmWeeyd/+9resvPLK9Vxl/arro7pbP5Pk7bffzpNPPpkVVlihQQZ2dV+urLnmmnnssceyyy67pEePHvnNb36TRo0aZfnll8/VV1+dn/70p98aVjUEnTt3zhFHHJF11lknSfLhhx+W9r399tt58cUXSxMvN1TbbLNNBg0alGbNmuVPf/pTrrzyytTW1qa6ujqvv/56HnvssSyzzDJp27ZtfZdaCE2bNs0OO+yQjh075uabb86rr76apGGNippR3Xn/7Gc/S4sWLXL//ffnlVdeKe1/++238+CDD6ZLly6lEZwN0YorrpiTTz45559/fn7/+99ntdVWK70/evvtt1NVVZWVV155ptE/i6rZhVGNGjUqhS1/+MMfsuGGG+bmm2/ORRddlM8//zzl5eWl/UsuuWTatWuXzz77bJHsq5qamjRu3DhdunRJklx66aW5+OKLk3z9fmjGUGDG24ZnDO3OOuusPPPMMz9+8T+i2V1HMy7sMqO695GTJk1Ks2bNSr/P3n///Zx77rn561//usjN//dtr7MZ+6euX2pra7PYYosl+fpOn7r3RBMnTky7du3SoUOHRfJ33Oz6aMbQrqKiIm3atMnPfvaz/Pvf/86rr76avn37Zt11183QoUNz8MEHZ/To0dlvv/3y/vvvF25whUUnFnF1E5yOGjUqLVu2TIsWLUr7OnfunH322SeNGjXKLrvsUo9V1p+Kior84he/SOfOnXP88cfnzDPPzK233pp27drlk08+yejRo3PmmWc2+BEJ31QX2p199tm59NJL06hRoxxyyCH1XVYhNGnSJJMnT85rr72W+++/P88991xuvvnmmW6fbciuvfba/PGPf8yGG26YZs2a5c0338wnn3ySm266qcFOHJwk3bt3z5JLLplevXrl0EMPnemWxq5du+buu+9u8D+H6kbPXXfddbn++utLiyq89tpr+fjjj3POOec06MCuUaNG2XnnndOhQ4eceOKJufDCC3PXXXeladOmmThxYsaPH5/rr7++Qb/OvmmllVbKiSeemKOPPjqXXXZZTj755NKH64ZqqaWWyimnnJLf/OY3OeGEE0q3wb7yyiv5+OOPc+ONN6Z169b1XWa9qvsw99FHH+XWW2/NpEmT0q5duzz11FP59NNPs8ceeyySH4pnNGMY9dhjj+XSSy/NV199lV/+8pdp3LhxvvrqqzRp0iRDhgzJIYcckr/+9a/57LPP8pvf/CadOnVK8vVKxF9++WXWX3/9RbK/6s7ps88+S7NmzbLCCivkiiuuSEVFRQYMGJDy8vLSgndJSiMQy8vLc8ABB6S8vDxnn312LrnkktJKqYua77qOZlwQ8Juqq6vTrFmzVFRUlMK6F154IbfffnuWW265ejiTBeP79M+MCyxNnjy5NJf2G2+8keHDh5e+SFjUzKmPZlz0Ztlll829996bu+66K+utt15OOOGELL744unfv38mT56cv//976X5f4tEYLcIq3vhvvrqqzn55JNz2GGHzTRsP0l++tOf5phjjpnptpmGaL311svNN9+cu+++O08++WSqqqqy0kor5aKLLsryyy9f3+UV0mqrrZbjjjsul1xySTbZZJP6Lqfe1b3ellpqqdTW1uacc87J5MmThXXf0L179yy77LJ54YUXUllZWZp8eoUVVqjv0upVx44dc9NNN6W8vLy0kEnyf7c0FvENRH1ZccUV07hx4/zzn/9M06ZN07Vr15x77rkN/hqqs9FGG+Wvf/1r7rrrrrz66quZNm1a1l9//ey222756U9/Wt/lFUptbW1+/vOf55BDDsmNN96Y5s2b13dJhbD99ttnscUWy3nnnZd77rknLVq0yMorr5w//OEP3hPl/4KYli1b5t///ndeeumlLLbYYllmmWVy3XXXZdlll63fAn8EcwqjmjRpUgrtrrrqqpx22mkZNmxYtttuu+yyyy756quv8u6772bChAmL7KCBuj76/PPPs9FGG+XQQw/NGWecUZoDesCAAbOELjOGdv369UujRo2y3nrrLZJhXTLn6+ib/VNTU1O6DXb8+PF54okncuONN+b5559fJN9vf5/+qWt7xRVX5O67787++++fTz/9NM8991xGjRqViy66aJGcNmRugvFp06alUaNG2XTTTXPnnXdm4403zjHHHFP68iBJjj322BxwwAGFnPKhrHZRjFophQevvfZaDjzwwKy11lr53e9+lw4dOtR3aQuNb/tWh5lNnTq1wY/8mdG7776b7bbbLo0bN87tt9+en/3sZ/VdUuF89dVXmT59eqZPn56mTZsukm8gWLAmTJiQSZMmlW7/ELTwQ0yZMqU0Sor/M3HixEycODFNmjTxs/pbTJgwIRMnTsz06dPTunXrBjeCde+9907btm1LYdQrr7ySAQMGZMCAAUlSCu2S5MEHH8wDDzyQRx99NM2bN8+yyy6bk046aZF+nzRu3Lisu+66OfDAA3Pcccfl1Vdfze9///tZ+umbnzka2meQOV1H3+yPs846K3/+85+z4oor5j//+U9uuummRXramTn1z4yjyC688MLce++9GTFiRFq1apXlllsup59+elZcccX6PIUFbk59lHw9Z/aLL76Y1VZbLUsuuWRp+4z9V0QCu0XY66+/nj333DObbLJJTj755AY958jcmnE48Yx/hrlVU1OT66+/Pr17916khuUDCxe/z4AFaW7DqG9+sfvZZ5+VVmOccaqeRdXTTz+dMWPGZJtttkny9S2KcxNKNRRzex3NGKrcdNNNOf3009OmTZtcd911i9zIuhnNbf/UjSJLvh59OGLEiLRt2zYtWrRY5OeInts+ShbO90MCu0VUdXV1rrrqqrz99ts54YQTZhryCSxYRf+mBgDgh5rbMGr69OmlKR4Wxg/M80PdQiTl5eUz9VP//v1z5JFHJmm4od33vY6mTp2ao446KgMHDkzXrl3rs/Qfxdz2T0O+62lRDsYFdouwSZMmpaampsENzwcAAH4cwqjvb8Z+OvLII9O/f//6Lqnezc11VBdKNcQvx73O5mxR7COBHQAAAPOFMGruvPHGGzn77LPzwgsv5Fe/+lUOOeSQ+i6pUFxH303/zNmi0EcNK5YGAABggVlttdUyaNCg9OjRI5deemmuuuqq+i6pkFZbbbUcd9xx2XDDDbPJJpvUdzmF4zr6bvpnzhaFPjLCDgAAgPnq1VdfzSWXXJKTTjopK6ywQn2XU1gNee6xueE6+m76Z84W5j4S2AEAADDfCaOYH1xH303/zNnC2kcCOwAAAAAoEHPYAQAAAECBCOwAAAAAoEAEdgAAAABQIAI7AAAAACgQgR0AAAAAFIjADgAAAAAKRGAHAAAAAAUisAMAAACAAqms7wIAACiOSy+9NJdddtlctV1qqaXy8MMPz9fj33HHHTnppJNy0kknpV+/fvP1uQEAFhYCOwAASnr27JkBAwbMtO1vf/tbPvnkk+y7775p1apVaftiiy0234+/8sorZ8CAAenevft8f24AgIVFWW1tbW19FwEAQHHts88+ee655/LQQw9l6aWXru9yAAAWeeawAwAAAIACEdgBADBPRo8enVNPPTW9e/fOaqutlt69e+fUU0/N6NGjZ2p36aWXpmvXrnnnnXdyxhlnZL311svaa6+dfv365cUXX5yp7R133JGuXbvmuuuum2n722+/nYEDB2bDDTfMmmuumZ122im33XZb3CwCACyKBHYAAHxvH330UXbaaaf89a9/zXLLLZe99947yy23XP76179m5513zscffzzLY0466aTcdddd2XrrrbPZZpvl5Zdfzn777ZcnnnjiO4/19NNPZ/fdd88DDzyQHj16ZI899siUKVPy61//OpdeeumCOkUAgHpj0QkAAL63U045Jf/9739zxhln5Be/+EVp+0033ZTf/va3GTRoUK6//vqZHvOf//wnf/vb37LMMsskSfbaa6/stddeOe2003L//fenvHzW75Krq6vz61//OrW1tRk6dGjWXHPNJMnRRx+dX/ziF7nyyivTt2/fLL744gvwbAEAflxG2AEA8L18+umneeaZZ9KjR4+Zwrrk6xBu9dVXzzPPPJMRI0bMtG/vvfcuhXVJssYaa2TrrbfOxx9/nJdffnm2x3rllVfyySefZIcddiiFdUnSpEmTnHjiiRkwYEC++uqr+Xh2AAD1T2AHAMD38tZbbyVJevToMdv9a621VpKv552bUc+ePWdp261bt9m2rVO3vXv37rPs22CDDXL44YenU6dOc1c4AMBCQmAHAMD3MmHChCTJYostNtv9HTp0SJJMmTJlpu0dO3acpe0SSywx03N+0/jx45MkLVu2nLdiAQAWQgI7+H/t3D8od20YB/CvP4NYSAmTIn8ymCQ2xc6mZJbJLBNKmTEqE4MUSZKFwaR+AyaTlUkhxeCZPOWht0e9b463z2c793Xuc19n/XbOBQB8SU1NTZLk5ubm0/pbyFZbW/tu/c8AL0nu7++TJHV1dZ8+q7q6Okny+Pj4ofby8pLn5+e/axoA4AcR2AEA8CVdXV1JklKp9Gn97OwsZWVlaWtre7d+cXHx4d632XVvv8b+qb29PUlyfn7+oXZwcJCenp7s7Oz8de8AAD+BwA4AgC9pbm5OX19fLi8vs7Gx8a62tbWVUqmUvr6+NDY2vqutra3l9vb293WpVMre3l66u7vT2dn56Vm9vb1pamrK7u7u79l5SfL8/Jz19fVUVFSkv7//X3w7AIDvV/ndDQAA8PPMz89nfHw8c3NzOTo6SkdHR66urnJ6epqGhoYsLCx82HN3d5fR0dEMDw/n4eEhh4eHqaqq+vTeN5WVlVlcXMzk5GTGxsYyPDyc+vr6HB8f5/r6OjMzM5/OxgMA+MkEdgAAfFlLS0u2t7ezurqa4+PjnJ2dpaGhIRMTE5mamkp9ff2HPbOzsymVStnf3095eXkGBwczPT2d1tbWfzxrYGAgm5ubWVlZycnJSZ6entLW1palpaWMjIz8R28IAPB9yl5fX1+/uwkAAP6/lpeXs7KyktXV1QwNDX13OwAAhWeGHQAAAAAUiMAOAAAAAApEYAcAAAAABWKGHQAAAAAUiC/sAAAAAKBABHYAAAAAUCACOwAAAAAoEIEdAAAAABSIwA4AAAAACkRgBwAAAAAFIrADAAAAgAIR2AEAAABAgQjsAAAAAKBAfgGR7x3/MYnxAAAAAABJRU5ErkJggg==",
+      "text/plain": [
+       "<Figure size 1500x800 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# Countplot shows the distribution of Publication\n",
+    "plt.rcParams['figure.figsize'] = [15, 8]\n",
+    "sns.set(font_scale = 1.2, style = 'darkgrid')\n",
+    "sns_year = sns.countplot(x=df_neg_top15['topic'], color = 'darkcyan')\n",
+    "plt.xticks(rotation=45)\n",
+    "sns_year.set(xlabel = \"Topic\", ylabel = \"Count\", title = \"Distribution of Topics\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sns.lineplot(data=df_negative, x=\"month\", y=\"passengers\")"
    ]
   },
   {


### PR DESCRIPTION
I added the updated version of the notebook and the dataframe with a column for the current topics I identified. Which topics are represented by which numbers can be seen in the BERTopic notebook. It would be nice to include a name for the topic instead of a number but this is a whole new rabbithole and I would suggest doing that after having the final set of topics :D 